### PR TITLE
feat(issue-59): Define shared contract ownership and package entry points

### DIFF
--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -1,0 +1,98 @@
+# @myclup/contracts
+
+Shared API schemas, Zod validation, and request/response contracts. Single source of truth for cross-app API boundaries.
+
+## Ownership
+
+| Concern | Location |
+|---------|----------|
+| API schemas | `packages/contracts` |
+| Zod validation | `packages/contracts` |
+| Request/response contracts | `packages/contracts` |
+| Domain types (framework-agnostic) | `packages/types` |
+
+- **Contract changes** must trigger updates in server implementation, `packages/api-client`, and affected app call sites.
+- **No duplication**: Apps must not redefine or copy contracts locally.
+- **API versioning**: All versioned endpoints use `/api/v1`.
+
+## File Layout
+
+```
+packages/contracts/
+├── src/
+│   ├── common/          # Shared schemas and utilities
+│   │   └── index.ts
+│   ├── health/          # Health check contracts
+│   │   ├── ping.ts
+│   │   └── index.ts
+│   └── index.ts         # Main package entry
+├── package.json
+├── tsconfig.json
+└── README.md
+```
+
+Domain folders follow the pattern: `src/<domain>/` (e.g. `src/bookings/`, `src/chat/`). Each domain exports its contracts via an `index.ts`.
+
+## Contract Pattern
+
+Every contract file defines:
+
+1. **Zod schema** — Request and response validation
+2. **Inferred types** — `z.infer<typeof Schema>`
+3. **Contract object** — `{ path, method, request, response }`
+
+Example:
+
+```typescript
+import { z } from "zod";
+
+export const PingRequestSchema = z.object({});
+export const PingResponseSchema = z.object({
+  status: z.literal("ok"),
+  timestamp: z.string().datetime(),
+});
+
+export type PingRequest = z.infer<typeof PingRequestSchema>;
+export type PingResponse = z.infer<typeof PingResponseSchema>;
+
+export const pingContract = {
+  path: "/api/v1/health/ping",
+  method: "GET" as const,
+  request: PingRequestSchema,
+  response: PingResponseSchema,
+} as const;
+```
+
+## Package Entry Points
+
+| Import | Contents |
+|--------|----------|
+| `@myclup/contracts` | All contracts (re-exports from domain folders) |
+| `@myclup/contracts/health` | Health contracts only |
+| `@myclup/contracts/common` | Common schemas and utilities |
+
+## Usage
+
+**Server (Next.js API route):**
+
+```typescript
+import { pingContract } from "@myclup/contracts";
+
+const data = pingContract.response.parse(responseBody);
+```
+
+**Client (api-client or app):**
+
+```typescript
+import { pingContract, PingResponse } from "@myclup/contracts";
+
+const res = await fetch(pingContract.path, { method: pingContract.method });
+const data = pingContract.response.parse(await res.json());
+```
+
+## Scripts
+
+- `pnpm build` — Compile TypeScript to `dist/`
+- `pnpm typecheck` — Type check without emit
+- `pnpm test` — Run unit tests
+- `pnpm lint` — ESLint and Prettier check

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -4,10 +4,28 @@
   "private": true,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./health": {
+      "types": "./dist/health/index.d.ts",
+      "default": "./dist/health/index.js"
+    },
+    "./common": {
+      "types": "./dist/common/index.d.ts",
+      "default": "./dist/common/index.js"
+    }
+  },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "build": "tsc",
-    "lint": "eslint . && prettier --check ."
+    "lint": "eslint . && prettier --check .",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "@myclup/config-eslint": "workspace:*",
@@ -16,6 +34,7 @@
     "@types/node": "^22.10.0",
     "eslint": "^9.15.0",
     "prettier": "^3.4.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^2.1.0"
   }
 }

--- a/packages/contracts/src/common/index.ts
+++ b/packages/contracts/src/common/index.ts
@@ -1,0 +1,5 @@
+/**
+ * @myclup/contracts/common — Shared common schemas and utilities.
+ * Domain-specific common schemas will be added as needed.
+ */
+export {};

--- a/packages/contracts/src/health/index.ts
+++ b/packages/contracts/src/health/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @myclup/contracts/health — Health check API contracts.
+ */
+export {
+  pingContract,
+  PingRequestSchema,
+  PingResponseSchema,
+} from "./ping";
+export type { PingRequest, PingResponse } from "./ping";

--- a/packages/contracts/src/health/ping.test.ts
+++ b/packages/contracts/src/health/ping.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { PingRequestSchema, PingResponseSchema, pingContract } from "./ping";
+
+describe("ping contract", () => {
+  describe("PingRequestSchema", () => {
+    it("validates empty object", () => {
+      expect(PingRequestSchema.parse({})).toEqual({});
+    });
+
+    it("strips unknown keys (empty request)", () => {
+      const result = PingRequestSchema.safeParse({ foo: "bar" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({});
+      }
+    });
+  });
+
+  describe("PingResponseSchema", () => {
+    it("validates correct response", () => {
+      const valid = {
+        status: "ok" as const,
+        timestamp: "2025-03-18T12:00:00.000Z",
+      };
+      expect(PingResponseSchema.parse(valid)).toEqual(valid);
+    });
+
+    it("rejects invalid status", () => {
+      const result = PingResponseSchema.safeParse({
+        status: "error",
+        timestamp: "2025-03-18T12:00:00.000Z",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects invalid timestamp format", () => {
+      const result = PingResponseSchema.safeParse({
+        status: "ok",
+        timestamp: "not-a-datetime",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects missing required fields", () => {
+      expect(PingResponseSchema.safeParse({})).toMatchObject({ success: false });
+      expect(PingResponseSchema.safeParse({ status: "ok" })).toMatchObject({
+        success: false,
+      });
+      expect(PingResponseSchema.safeParse({ timestamp: "2025-03-18T12:00:00.000Z" })).toMatchObject({
+        success: false,
+      });
+    });
+  });
+
+  describe("pingContract", () => {
+    it("has correct path and method", () => {
+      expect(pingContract.path).toBe("/api/v1/health/ping");
+      expect(pingContract.method).toBe("GET");
+    });
+
+    it("exposes request and response schemas", () => {
+      expect(pingContract.request).toBe(PingRequestSchema);
+      expect(pingContract.response).toBe(PingResponseSchema);
+    });
+  });
+});

--- a/packages/contracts/src/health/ping.ts
+++ b/packages/contracts/src/health/ping.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+/** Request schema for health ping endpoint. No body required. */
+export const PingRequestSchema = z.object({});
+
+/** Response schema for health ping endpoint. */
+export const PingResponseSchema = z.object({
+  status: z.literal("ok"),
+  timestamp: z.string().datetime(),
+});
+
+/** Inferred request type. */
+export type PingRequest = z.infer<typeof PingRequestSchema>;
+
+/** Inferred response type. */
+export type PingResponse = z.infer<typeof PingResponseSchema>;
+
+/** Contract definition: path, method, request and response schemas. */
+export const pingContract = {
+  path: "/api/v1/health/ping",
+  method: "GET" as const,
+  request: PingRequestSchema,
+  response: PingResponseSchema,
+} as const;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,5 +1,7 @@
 /**
- * @myclup/contracts — Shared API schemas, validation, request/response contracts.
- * Domain contracts will be added in Epic #14.
+ * @myclup/contracts — Shared API schemas, Zod validation, request/response contracts.
+ *
+ * Ownership: API schemas, input/output validation, and cross-app contracts.
+ * API versioning: /api/v1.
  */
-export {};
+export * from "./health";

--- a/packages/contracts/vitest.config.ts
+++ b/packages/contracts/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,10 @@ importers:
   packages/config-typescript: {}
 
   packages/contracts:
+    dependencies:
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
     devDependencies:
       '@myclup/config-eslint':
         specifier: workspace:*
@@ -102,6 +106,9 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.19.15)
 
   packages/supabase:
     devDependencies:
@@ -114,6 +121,12 @@ importers:
       '@myclup/config-typescript':
         specifier: workspace:*
         version: link:../config-typescript
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.15
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
 
   packages/ui-native:
     devDependencies:
@@ -1379,6 +1392,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
@@ -2506,3 +2522,5 @@ snapshots:
   word-wrap@1.2.5: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.25.76: {}


### PR DESCRIPTION
Closes #59

Epic: #14

## Summary

Implements shared contract ownership and package entry points for `packages/contracts` per Task 14.1.

## Acceptance Criteria

- [x] packages/contracts has zod as a dependency
- [x] packages/contracts has clear exports map
- [x] Domain-based folder structure exists (src/common/, src/health/)
- [x] At least one example contract with schema + contract object
- [x] Contract pattern: Zod schema → inferred type → { path, method, request, response }
- [x] README describes ownership and file layout
- [x] pnpm build and pnpm typecheck pass

## Required Tests

- [x] Unit test verifying example contract schema validates/rejects correctly (src/health/ping.test.ts)

## Validation

- `pnpm build` — passed
- `pnpm typecheck` — passed
- `pnpm test` (packages/contracts) — 8 tests passed