### PR TITLE
feat(issue-62): Establish typed API client expectations for all product surfaces

### DIFF
--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -1,0 +1,103 @@
+# @myclup/api-client
+
+Shared typed API client for all MyClup product surfaces. Web and mobile apps must consume BFF endpoints through this package. **No app may introduce a second network client.**
+
+## Installation
+
+The package is part of the monorepo. Add it as a dependency:
+
+```json
+{
+  "dependencies": {
+    "@myclup/api-client": "workspace:*"
+  }
+}
+```
+
+## Configuration
+
+### Web (Next.js, React)
+
+```typescript
+// apps/web-gym-admin or apps/web-site
+import { createApi } from "@myclup/api-client";
+
+const api = createApi({
+  baseUrl: process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000",
+  headers: {
+    // Auth headers injected when session is available (Epic #15)
+    // Authorization: `Bearer ${token}`,
+  },
+});
+
+// Typed domain methods
+const result = await api.health.ping();
+```
+
+**Base URL for web:**
+
+- **Development**: `http://localhost:3000` (Next.js BFF)
+- **Production**: `https://your-domain.com` or your BFF origin
+- Use `NEXT_PUBLIC_*` env vars for client-side config
+
+### Mobile (Expo / React Native)
+
+```typescript
+// apps/mobile-user or apps/mobile-admin
+import { createApi } from "@myclup/api-client";
+
+const api = createApi({
+  baseUrl: process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3000",
+  headers: {
+    // Auth headers when token is available (Epic #15)
+    // Authorization: `Bearer ${token}`,
+  },
+});
+
+const result = await api.health.ping();
+```
+
+**Base URL for mobile:**
+
+- **Development**: `http://localhost:3000` or your machine IP (e.g. `http://192.168.1.10:3000`) for device/simulator
+- **Production**: `https://api.your-domain.com`
+- Use `EXPO_PUBLIC_*` env vars for runtime config in Expo
+
+## Usage
+
+All domain methods are typed and validated against shared contracts from `@myclup/contracts`:
+
+```typescript
+const api = createApi({ baseUrl: "https://api.example.com" });
+
+// health.ping() — GET /api/v1/health/ping
+const ping = await api.health.ping();
+// ping: { status: "ok"; timestamp: string }
+```
+
+## Error Handling
+
+- **Non-2xx response**: Throws `ApiError` with `status` and `body`
+- **Invalid response shape**: Throws `ZodError` from `contract.response.parse()`
+
+```typescript
+try {
+  await api.health.ping();
+} catch (err) {
+  if (err instanceof ApiError) {
+    console.error(err.status, err.body);
+  }
+  throw err;
+}
+```
+
+## Contract Consumption
+
+The client uses contracts from `@myclup/contracts`:
+
+1. Import contract (path, method, request/response schemas)
+2. Fetch endpoint
+3. Parse response with `contract.response.parse()`
+4. Return typed result
+
+New domain methods follow this pattern. See `src/health.ts` for the example implementation.

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -2,7 +2,32 @@
   "name": "@myclup/api-client",
   "version": "0.0.0",
   "private": true,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "tsc",
+    "lint": "eslint . && prettier --check .",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@myclup/contracts": "workspace:*",
+    "zod": "^3.24.0"
+  },
   "devDependencies": {
-    "@myclup/config-typescript": "workspace:*"
+    "@myclup/config-eslint": "workspace:*",
+    "@myclup/config-prettier": "workspace:*",
+    "@myclup/config-typescript": "workspace:*",
+    "@types/node": "^22.10.0",
+    "eslint": "^9.15.0",
+    "prettier": "^3.4.0",
+    "typescript": "^5.7.0",
+    "vitest": "^2.1.0"
   }
 }

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -1,0 +1,76 @@
+import type { z } from "zod";
+
+/** Contract shape: path, method, optional request schema, response schema. */
+export type ApiContract<TRequest = unknown, TResponse = unknown> = {
+  path: string;
+  method: string;
+  request?: z.ZodType<TRequest>;
+  response: z.ZodType<TResponse>;
+};
+
+/** Configuration for the API client. */
+export type ApiClientConfig = {
+  /** Base URL for all requests (e.g. https://api.example.com). Trailing slash is normalized. */
+  baseUrl: string;
+  /** Optional headers to inject (e.g. Authorization). Applied to every request. */
+  headers?: Record<string, string>;
+  /** Custom fetch implementation (for testing or custom behavior). */
+  fetch?: typeof fetch;
+};
+
+/** Thrown when the API returns a non-2xx status or response fails validation. */
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status?: number,
+    public readonly body?: string
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+/**
+ * Creates an API client with configurable base URL and optional auth headers.
+ * All BFF calls from web and mobile apps should go through this client.
+ */
+export function createApiClient(config: ApiClientConfig) {
+  const baseUrl = config.baseUrl.replace(/\/$/, "");
+  const headers = config.headers ?? {};
+  const doFetch = config.fetch ?? fetch;
+
+  /**
+   * Performs a contract-based request. Fetches the endpoint, parses the response
+   * with contract.response.parse(), and returns the typed result.
+   */
+  async function request<T>(
+    contract: ApiContract<unknown, T>,
+    requestData?: unknown
+  ): Promise<T> {
+    const url = `${baseUrl}${contract.path}`;
+    const init: RequestInit = {
+      method: contract.method,
+      headers: { "Content-Type": "application/json", ...headers },
+    };
+
+    if (requestData !== undefined && contract.method !== "GET") {
+      init.body = JSON.stringify(requestData);
+    }
+
+    const res = await doFetch(url, init);
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new ApiError(
+        `API request failed: ${res.status} ${res.statusText}`,
+        res.status,
+        body
+      );
+    }
+
+    const json = await res.json();
+    return contract.response.parse(json) as T;
+  }
+
+  return { request };
+}

--- a/packages/api-client/src/health.test.ts
+++ b/packages/api-client/src/health.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createApi } from "./index";
+
+describe("api-client health.ping", () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+  });
+
+  it("parses valid response correctly", async () => {
+    const validResponse = {
+      status: "ok",
+      timestamp: "2025-03-18T12:00:00.000Z",
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(validResponse),
+    });
+
+    const api = createApi({
+      baseUrl: "https://api.example.com",
+      fetch: mockFetch,
+    });
+
+    const result = await api.health.ping();
+
+    expect(result).toEqual(validResponse);
+    expect(result.status).toBe("ok");
+    expect(result.timestamp).toBe("2025-03-18T12:00:00.000Z");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.example.com/api/v1/health/ping",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+        }),
+      })
+    );
+  });
+
+  it("throws on invalid response shape", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ status: "invalid", foo: "bar" }),
+    });
+
+    const api = createApi({
+      baseUrl: "https://api.example.com",
+      fetch: mockFetch,
+    });
+
+    await expect(api.health.ping()).rejects.toThrow();
+  });
+
+  it("throws on non-2xx status", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      text: () => Promise.resolve("Server error"),
+    });
+
+    const api = createApi({
+      baseUrl: "https://api.example.com",
+      fetch: mockFetch,
+    });
+
+    await expect(api.health.ping()).rejects.toMatchObject({
+      name: "ApiError",
+      status: 500,
+    });
+  });
+
+  it("injects optional headers", async () => {
+    const validResponse = {
+      status: "ok",
+      timestamp: "2025-03-18T12:00:00.000Z",
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(validResponse),
+    });
+
+    const api = createApi({
+      baseUrl: "https://api.example.com",
+      headers: { Authorization: "Bearer token123" },
+      fetch: mockFetch,
+    });
+
+    await api.health.ping();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer token123",
+        }),
+      })
+    );
+  });
+});

--- a/packages/api-client/src/health.ts
+++ b/packages/api-client/src/health.ts
@@ -1,0 +1,23 @@
+import type { PingResponse } from "@myclup/contracts/health";
+import { pingContract } from "@myclup/contracts/health";
+import type { ApiContract } from "./client";
+
+type RequestFn = <T>(
+  contract: ApiContract<unknown, T>,
+  requestData?: unknown
+) => Promise<T>;
+
+/**
+ * Creates the health API with typed methods. Uses the shared ping contract
+ * for request/response validation.
+ */
+export function createHealthApi(request: RequestFn) {
+  return {
+    /** Calls GET /api/v1/health/ping and parses response with contract.response.parse() */
+    async ping(): Promise<PingResponse> {
+      return request(
+        pingContract as ApiContract<unknown, PingResponse>
+      );
+    },
+  };
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,0 +1,28 @@
+/**
+ * @myclup/api-client — Shared typed API client for all product surfaces.
+ *
+ * Web and mobile apps must use this package for BFF calls. No app may introduce
+ * a second network client.
+ */
+export { createApiClient, ApiError, type ApiClientConfig, type ApiContract } from "./client";
+export { createHealthApi } from "./health";
+export type { PingResponse } from "@myclup/contracts/health";
+
+import { createApiClient } from "./client";
+import { createHealthApi } from "./health";
+import type { ApiClientConfig } from "./client";
+
+/**
+ * Creates the full API surface with base URL and optional headers.
+ * Use this in web and mobile apps to get typed domain methods.
+ *
+ * @example
+ * const api = createApi({ baseUrl: "https://api.example.com" });
+ * const result = await api.health.ping();
+ */
+export function createApi(config: ApiClientConfig) {
+  const client = createApiClient(config);
+  return {
+    health: createHealthApi(client.request),
+  };
+}

--- a/packages/api-client/tsconfig.json
+++ b/packages/api-client/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@myclup/config-typescript/node",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/api-client/vitest.config.ts
+++ b/packages/api-client/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,10 +38,38 @@ importers:
   apps/web-site: {}
 
   packages/api-client:
+    dependencies:
+      '@myclup/contracts':
+        specifier: workspace:*
+        version: link:../contracts
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
     devDependencies:
+      '@myclup/config-eslint':
+        specifier: workspace:*
+        version: link:../config-eslint
+      '@myclup/config-prettier':
+        specifier: workspace:*
+        version: link:../config-prettier
       '@myclup/config-typescript':
         specifier: workspace:*
         version: link:../config-typescript
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.15
+      eslint:
+        specifier: ^9.15.0
+        version: 9.39.4(jiti@1.21.7)
+      prettier:
+        specifier: ^3.4.0
+        version: 3.8.1
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.19.15)
 
   packages/config-eslint:
     dependencies:


### PR DESCRIPTION
Closes #62

Epic: #14

## Summary

Implements the shared typed API client layer in `packages/api-client` so all product surfaces (mobile-user, mobile-admin, web-gym-admin, web-platform-admin, web-site) consume BFF endpoints through this single client.

## Changes

- Added `packages/api-client` src/ structure and build configuration
- Base fetch wrapper: configurable base URL, optional auth headers injection, error handling
- Contract-based request/response: given contract from @myclup/contracts, fetch endpoint, parse response with `contract.response.parse()`
- Typed `health.ping()` method using ping contract from Task 14.1
- README documenting web and mobile configuration
- Unit tests with mocked fetch: parses valid response, throws on invalid response, throws on non-2xx, injects optional headers

## Acceptance Criteria

- [x] src/ with base client and one typed domain method (health.ping())
- [x] Configurable base URL and headers
- [x] Contract consumption: contract.response.parse()
- [x] Example method implemented and typed
- [x] README for web and mobile config
- [x] pnpm build and typecheck pass
- [x] Unit test with mocked fetch verifying health.ping() parses response correctly and throws on invalid response

## Validation

```
pnpm build
pnpm typecheck
pnpm test --filter=@myclup/api-client
```

All pass.