### PR TITLE
feat(issue-60): Define Supabase shared client and generated type responsibilities

### DIFF
--- a/packages/supabase/README.md
+++ b/packages/supabase/README.md
@@ -1,0 +1,115 @@
+# @myclup/supabase
+
+Shared Supabase package for MyClup: database type generation, server-side clients, SQL conventions, and RLS guidance.
+
+## ⚠️ Server-Only Boundary
+
+**Client apps must NOT import `@myclup/supabase`.**
+
+| Allowed | Forbidden |
+|---------|-----------|
+| Next.js BFF routes, API handlers | `apps/mobile-user` |
+| Server actions, server modules | `apps/mobile-admin` |
+| Build scripts, migrations | `apps/web-gym-admin` (UI code) |
+| | `apps/web-platform-admin` (UI code) |
+| | `apps/web-site` (UI code) |
+
+All Supabase access from client surfaces goes through the Next.js BFF and `@myclup/api-client`. Never call Supabase directly from client code.
+
+---
+
+## Package Structure
+
+```
+packages/supabase/
+├── src/
+│   ├── index.ts              # Main entry (client factory, re-exports)
+│   ├── client/
+│   │   ├── index.ts          # Client exports
+│   │   └── create-server-client.ts
+│   └── generated/            # ← Generated DB types live here
+│       └── database.types.ts
+├── dist/                     # Compiled output (from tsc build)
+├── README.md
+├── package.json
+└── tsconfig.json
+```
+
+### Entry Points
+
+- **`@myclup/supabase`** — Main: `createServerClient`, `Database`, `Json`
+- **`@myclup/supabase/client`** — Client factory only
+- **`@myclup/supabase/generated`** — Raw DB types (advanced use)
+
+---
+
+## Generated Database Types
+
+**Location**: `src/generated/database.types.ts`
+
+Until a Supabase project is provisioned, this file contains a placeholder schema. When the database exists:
+
+```bash
+# From repo root or packages/supabase
+pnpm exec supabase gen types typescript --project-id <project-ref> > packages/supabase/src/generated/database.types.ts
+```
+
+Or use the placeholder script (logs the command):
+
+```bash
+pnpm --filter @myclup/supabase generate:types
+```
+
+**Convention**: Commit generated types to version control. Regenerate when schema changes.
+
+---
+
+## Server Client Usage
+
+```typescript
+import { createServerClient } from "@myclup/supabase";
+
+// In API route or server module — read from env
+const client = createServerClient({
+  supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  serviceRoleKey: process.env.SUPABASE_SERVICE_ROLE_KEY!,
+});
+
+// Client bypasses RLS; enforce tenant and permission checks in app logic
+const { data, error } = await client.from("gyms").select("*").eq("id", gymId);
+```
+
+**Important**: The service role key bypasses Row Level Security. Always verify tenant scope and user permissions server-side before any write or sensitive read.
+
+---
+
+## SQL Conventions
+
+- **Schema**: Prefer `public` schema unless a separate schema is justified
+- **Migrations**: Use `supabase/migrations/` at repo root (or as documented in project setup)
+- **Naming**: snake_case for tables and columns
+- **IDs**: Use `uuid` for primary keys; `gen_random_uuid()` default
+- **Timestamps**: `created_at`, `updated_at` (timestamptz)
+- **Tenant columns**: All tenant-owned tables must have `gym_id` (and optionally `branch_id`)
+
+---
+
+## RLS (Row Level Security) Conventions
+
+- **Mandatory** for tenant-owned data
+- **Policies**: Explicit `USING` and `WITH CHECK` expressions; avoid permissive defaults
+- **Tenant isolation**: Every policy on tenant tables must filter by `gym_id` (and `branch_id` when applicable)
+- **Service role**: Bypasses RLS; server code using service role must enforce checks in application logic
+- **Anon/authenticated**: Used only for client-side Supabase access where BFF delegates; RLS must restrict to authorized rows
+- **Cross-tenant**: Denied by default; platform admin elevated access requires audit trail
+
+---
+
+## Environment Variables
+
+| Variable | Where | Purpose |
+|----------|-------|---------|
+| `NEXT_PUBLIC_SUPABASE_URL` | BFF / server | Supabase project URL |
+| `SUPABASE_SERVICE_ROLE_KEY` | Server only | Service role key (bypasses RLS) |
+
+Never expose `SUPABASE_SERVICE_ROLE_KEY` to client bundles.

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -2,7 +2,40 @@
   "name": "@myclup/supabase",
   "version": "0.0.0",
   "private": true,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./client": {
+      "types": "./dist/client/index.d.ts",
+      "default": "./dist/client/index.js"
+    },
+    "./generated": {
+      "types": "./dist/generated/database.types.d.ts",
+      "default": "./dist/generated/database.types.js"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "tsc",
+    "lint": "eslint . && prettier --check .",
+    "test": "vitest run",
+    "generate:types": "echo 'Run: supabase gen types typescript --project-id <id> > src/generated/database.types.ts'"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.47.0"
+  },
   "devDependencies": {
-    "@myclup/config-typescript": "workspace:*"
+    "@myclup/config-eslint": "workspace:*",
+    "@myclup/config-prettier": "workspace:*",
+    "@myclup/config-typescript": "workspace:*",
+    "@types/node": "^22.10.0",
+    "eslint": "^9.15.0",
+    "prettier": "^3.4.0",
+    "typescript": "^5.7.0",
+    "vitest": "^2.1.0"
   }
 }

--- a/packages/supabase/src/client/create-server-client.test.ts
+++ b/packages/supabase/src/client/create-server-client.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { createServerClient } from "./create-server-client";
+
+describe("createServerClient", () => {
+  const validUrl = "https://test.supabase.co";
+  const validKey = "test-service-role-key-at-least-32-chars-long";
+
+  it("returns a client instance when given valid options", () => {
+    const client = createServerClient({
+      supabaseUrl: validUrl,
+      serviceRoleKey: validKey,
+    });
+    expect(client).toBeDefined();
+    expect(typeof client.from).toBe("function");
+    expect(typeof client.auth.getSession).toBe("function");
+  });
+
+  it("throws if supabaseUrl is missing", () => {
+    expect(() =>
+      createServerClient({
+        supabaseUrl: "",
+        serviceRoleKey: validKey,
+      })
+    ).toThrow("supabaseUrl is required");
+  });
+
+  it("throws if supabaseUrl is whitespace only", () => {
+    expect(() =>
+      createServerClient({
+        supabaseUrl: "   ",
+        serviceRoleKey: validKey,
+      })
+    ).toThrow("supabaseUrl is required");
+  });
+
+  it("throws if serviceRoleKey is missing", () => {
+    expect(() =>
+      createServerClient({
+        supabaseUrl: validUrl,
+        serviceRoleKey: "",
+      })
+    ).toThrow("serviceRoleKey is required");
+  });
+
+  it("throws if serviceRoleKey is whitespace only", () => {
+    expect(() =>
+      createServerClient({
+        supabaseUrl: validUrl,
+        serviceRoleKey: "   ",
+      })
+    ).toThrow("serviceRoleKey is required");
+  });
+});

--- a/packages/supabase/src/client/create-server-client.ts
+++ b/packages/supabase/src/client/create-server-client.ts
@@ -1,0 +1,61 @@
+/**
+ * Server-side Supabase client factory.
+ *
+ * ⚠️ SERVER-ONLY: This module must never be imported by client apps
+ * (mobile-user, mobile-admin, web-gym-admin UI, web-platform-admin UI, web-site UI).
+ * Only BFF routes, API handlers, server actions, and server modules may use it.
+ *
+ * Uses SUPABASE_SERVICE_ROLE_KEY which bypasses RLS. All tenant and permission
+ * checks must be enforced in application logic—never rely on client-side checks.
+ */
+
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "../generated/database.types";
+
+export type ServerSupabaseClient = SupabaseClient<Database>;
+
+export interface CreateServerClientOptions {
+  /** Supabase project URL (from NEXT_PUBLIC_SUPABASE_URL or SUPABASE_URL) */
+  supabaseUrl: string;
+  /** Service role key — bypasses RLS; never expose to clients */
+  serviceRoleKey: string;
+  /** Optional: override default options passed to createClient */
+  options?: Parameters<typeof createClient<Database>>[2];
+}
+
+/**
+ * Creates a server-side Supabase client with service role privileges.
+ *
+ * This client bypasses Row Level Security. The caller is responsible for:
+ * - Verifying user identity and tenant scope before any write
+ * - Enforcing permission checks in application logic
+ * - Never passing tenant_id or branch_id from the client without server-side validation
+ *
+ * @param options - supabaseUrl and serviceRoleKey (from env)
+ * @returns Typed Supabase client for server use
+ * @throws Error if supabaseUrl or serviceRoleKey are missing or invalid
+ */
+export function createServerClient(
+  options: CreateServerClientOptions
+): ServerSupabaseClient {
+  const { supabaseUrl, serviceRoleKey, options: clientOptions } = options;
+
+  if (!supabaseUrl?.trim()) {
+    throw new Error(
+      "createServerClient: supabaseUrl is required. Set NEXT_PUBLIC_SUPABASE_URL or SUPABASE_URL."
+    );
+  }
+  if (!serviceRoleKey?.trim()) {
+    throw new Error(
+      "createServerClient: serviceRoleKey is required. Set SUPABASE_SERVICE_ROLE_KEY (server-only, never expose)."
+    );
+  }
+
+  return createClient<Database>(supabaseUrl, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+    ...clientOptions,
+  });
+}

--- a/packages/supabase/src/client/index.ts
+++ b/packages/supabase/src/client/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Server-side Supabase client exports.
+ *
+ * Entry point for BFF and server modules. Do not import from client apps.
+ */
+export {
+  createServerClient,
+  type CreateServerClientOptions,
+  type ServerSupabaseClient,
+} from "./create-server-client";

--- a/packages/supabase/src/generated/database.types.ts
+++ b/packages/supabase/src/generated/database.types.ts
@@ -1,0 +1,31 @@
+/**
+ * Generated Supabase database types.
+ *
+ * This file is the canonical location for output from:
+ *   supabase gen types typescript --project-id <id> > src/generated/database.types.ts
+ *
+ * Until a Supabase project is provisioned and linked, this placeholder schema
+ * provides minimal types so the server client can typecheck. Replace the contents
+ * with real generated types when the database exists.
+ *
+ * See packages/supabase/README.md for type generation instructions.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+export interface Database {
+  public: {
+    Tables: Record<string, never>;
+    Views: Record<string, never>;
+    Functions: Record<string, never>;
+    Enums: Record<string, never>;
+  };
+}

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -1,0 +1,22 @@
+/**
+ * @myclup/supabase — DB types, shared clients, SQL/RLS conventions, server helpers.
+ *
+ * ⚠️ SERVER-ONLY PACKAGE
+ * Client apps (mobile-user, mobile-admin, web-gym-admin UI, web-platform-admin UI,
+ * web-site UI) must NOT import @myclup/supabase. All Supabase access from client
+ * surfaces goes through the Next.js BFF and api-client. Only BFF routes, API
+ * handlers, server actions, and server modules may use this package.
+ *
+ * Ownership:
+ * - Database type generation outputs (src/generated/)
+ * - Server-side Supabase client factory
+ * - SQL conventions and RLS guidance
+ */
+
+export {
+  createServerClient,
+  type CreateServerClientOptions,
+  type ServerSupabaseClient,
+} from "./client/index";
+
+export type { Database, Json } from "./generated/database.types";

--- a/packages/supabase/tsconfig.json
+++ b/packages/supabase/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@myclup/config-typescript/node",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/supabase/vitest.config.ts
+++ b/packages/supabase/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,10 +186,35 @@ importers:
         version: 2.1.9(@types/node@22.19.15)
 
   packages/supabase:
+    dependencies:
+      '@supabase/supabase-js':
+        specifier: ^2.47.0
+        version: 2.99.2
     devDependencies:
+      '@myclup/config-eslint':
+        specifier: workspace:*
+        version: link:../config-eslint
+      '@myclup/config-prettier':
+        specifier: workspace:*
+        version: link:../config-prettier
       '@myclup/config-typescript':
         specifier: workspace:*
         version: link:../config-typescript
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.15
+      eslint:
+        specifier: ^9.15.0
+        version: 9.39.4(jiti@1.21.7)
+      prettier:
+        specifier: ^3.4.0
+        version: 3.8.1
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.19.15)
 
   packages/types:
     devDependencies:
@@ -222,6 +247,10 @@ importers:
         version: link:../config-typescript
 
   packages/utils:
+    dependencies:
+      '@myclup/types':
+        specifier: workspace:*
+        version: link:../types
     devDependencies:
       '@myclup/config-typescript':
         specifier: workspace:*
@@ -780,6 +809,30 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@supabase/auth-js@2.99.2':
+    resolution: {integrity: sha512-uRGNXMKEw4VhwouNW7N0XDAGqJP9redHNDmWi17dTrcO1lvFfyRiXsqqfgnVC8aqtRn8kLkLPEzHjiRWsni+oQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.99.2':
+    resolution: {integrity: sha512-xuXQARvjdfB1UPK1yUceZ5EGjOLkVz4rBAaloS9foXiAuseWEdgWBCxkIAFRxGBLGX8Uzo8kseq90jhPb+07Vg==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/postgrest-js@2.99.2':
+    resolution: {integrity: sha512-ueiOVkbkTQ7RskwVmjR8zxWYw3VKOMxo1+qep+Dx/SgApqyhWBGd92waQb45tbLc7ydB5x8El8utXOLQTuTojQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.99.2':
+    resolution: {integrity: sha512-J6Jm9601dkpZf3+EJ48ki2pM4sFtCNm/BI0l8iEnrczgg+JSEQkMoOW5VSpM54t0pNs69bsz5PTmYJahDZKiIQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/storage-js@2.99.2':
+    resolution: {integrity: sha512-V/FF8kX8JGSefsVCG1spCLSrHdNR/JFeUMn1jS9KG/Eizjx+evtdKQKLJXFgIylY/bKTXKhc2SYDPIGrIhzsug==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.99.2':
+    resolution: {integrity: sha512-179rn5wq0wBAqqGwAwR7TUGg2NOaP+fkd5FCVbYJXby85fsRNPFoNJN8YRBepqX2tN7JJcnTjqaAMXuNjiyisA==}
+    engines: {node: '>=20.0.0'}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -792,6 +845,9 @@ packages:
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
 
+  '@types/phoenix@1.6.7':
+    resolution: {integrity: sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -799,6 +855,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.57.1':
     resolution: {integrity: sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==}
@@ -1175,6 +1234,10 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1735,6 +1798,18 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -2105,6 +2180,44 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
+  '@supabase/auth-js@2.99.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.99.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/postgrest-js@2.99.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.99.2':
+    dependencies:
+      '@types/phoenix': 1.6.7
+      '@types/ws': 8.18.1
+      tslib: 2.8.1
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/storage-js@2.99.2':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.99.2':
+    dependencies:
+      '@supabase/auth-js': 2.99.2
+      '@supabase/functions-js': 2.99.2
+      '@supabase/postgrest-js': 2.99.2
+      '@supabase/realtime-js': 2.99.2
+      '@supabase/storage-js': 2.99.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -2117,6 +2230,8 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/phoenix@1.6.7': {}
+
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -2124,6 +2239,10 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.19.15
 
   '@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
@@ -2550,6 +2669,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  iceberg-js@0.8.1: {}
 
   ignore@5.3.2: {}
 
@@ -3094,6 +3215,8 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  ws@8.19.0: {}
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
Closes #60

**Epic**: #14

## Summary

Establishes `packages/supabase` as the home for database type generation outputs, shared Supabase clients, SQL conventions, RLS guidance, and server helper utilities. Defines ownership boundaries so apps and BFF never bypass this package for Supabase access.

## Acceptance Criteria

- [x] `src/` structure with documented entry points
- [x] Documented location for generated DB types (`src/generated/database.types.ts`)
- [x] Server-side client helper (`createServerClient`) with typed interface
- [x] README: generated types, server usage, SQL/RLS conventions, server-only boundary
- [x] `package.json` main/types/exports for BFF import
- [x] `pnpm typecheck` passes

## Required Tests

- [x] Unit tests asserting server client can be instantiated and validation (url/key checks)

## Validation

```bash
pnpm --filter @myclup/supabase typecheck  # passes
pnpm --filter @myclup/supabase test       # 5 tests pass
pnpm typecheck                            # full monorepo passes
```