### PR TITLE
feat(issue-70): Auth and profile contracts

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -13,6 +13,10 @@
       "types": "./dist/health/index.d.ts",
       "default": "./dist/health/index.js"
     },
+    "./auth": {
+      "types": "./dist/auth/index.d.ts",
+      "default": "./dist/auth/index.js"
+    },
     "./common": {
       "types": "./dist/common/index.d.ts",
       "default": "./dist/common/index.js"
@@ -25,6 +29,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@myclup/types": "workspace:*",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/packages/contracts/src/auth/index.ts
+++ b/packages/contracts/src/auth/index.ts
@@ -1,0 +1,23 @@
+/**
+ * @myclup/contracts/auth — Auth and profile API contracts.
+ */
+export {
+  whoamiContract,
+  WhoamiRequestSchema,
+  WhoamiResponseSchema,
+} from "./whoami";
+export type { WhoamiRequest, WhoamiResponse } from "./whoami";
+
+export {
+  sessionContract,
+  SessionRequestSchema,
+  SessionResponseSchema,
+} from "./session";
+export type { SessionRequest, SessionResponse } from "./session";
+
+export {
+  profilePatchContract,
+  ProfilePatchRequestSchema,
+  ProfilePatchResponseSchema,
+} from "./profile";
+export type { ProfilePatchRequest, ProfilePatchResponse } from "./profile";

--- a/packages/contracts/src/auth/profile.test.ts
+++ b/packages/contracts/src/auth/profile.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import {
+  ProfilePatchRequestSchema,
+  ProfilePatchResponseSchema,
+  profilePatchContract,
+} from "./profile";
+
+describe("profile contract", () => {
+  describe("ProfilePatchRequestSchema", () => {
+    it("accepts empty object (all optional)", () => {
+      expect(ProfilePatchRequestSchema.parse({})).toEqual({});
+    });
+
+    it("accepts displayName only", () => {
+      const input = { displayName: "New Name" };
+      expect(ProfilePatchRequestSchema.parse(input)).toEqual(input);
+    });
+
+    it("accepts avatarUrl only", () => {
+      const input = { avatarUrl: "https://example.com/avatar.png" };
+      expect(ProfilePatchRequestSchema.parse(input)).toEqual(input);
+    });
+
+    it("accepts avatarUrl: null", () => {
+      const input = { avatarUrl: null };
+      expect(ProfilePatchRequestSchema.parse(input)).toEqual(input);
+    });
+
+    it("accepts localePreference only", () => {
+      const input = { localePreference: { locale: "tr" as const } };
+      expect(ProfilePatchRequestSchema.parse(input)).toEqual(input);
+    });
+
+    it("accepts full localePreference with fallbackLocale", () => {
+      const input = {
+        localePreference: { locale: "en" as const, fallbackLocale: "tr" as const },
+      };
+      expect(ProfilePatchRequestSchema.parse(input)).toEqual(input);
+    });
+
+    it("rejects empty displayName", () => {
+      const result = ProfilePatchRequestSchema.safeParse({ displayName: "" });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects invalid avatarUrl format", () => {
+      const result = ProfilePatchRequestSchema.safeParse({
+        avatarUrl: "not-a-valid-url",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects invalid locale", () => {
+      const result = ProfilePatchRequestSchema.safeParse({
+        localePreference: { locale: "fr" },
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("ProfilePatchResponseSchema", () => {
+    const validProfile = {
+      userId: "user-uuid",
+      displayName: "Test User",
+      avatarUrl: "https://example.com/avatar.png",
+      localePreference: { locale: "en" as const, fallbackLocale: "tr" as const },
+      createdAt: "2025-03-18T12:00:00.000Z",
+      updatedAt: "2025-03-18T12:00:00.000Z",
+    };
+
+    it("validates full UserProfile response", () => {
+      expect(ProfilePatchResponseSchema.parse(validProfile)).toEqual(validProfile);
+    });
+
+    it("accepts null avatarUrl", () => {
+      const withNull = { ...validProfile, avatarUrl: null };
+      expect(ProfilePatchResponseSchema.parse(withNull).avatarUrl).toBeNull();
+    });
+
+    it("rejects missing required fields", () => {
+      expect(ProfilePatchResponseSchema.safeParse({})).toMatchObject({
+        success: false,
+      });
+    });
+  });
+
+  describe("profilePatchContract", () => {
+    it("has correct path and method", () => {
+      expect(profilePatchContract.path).toBe("/api/v1/auth/profile");
+      expect(profilePatchContract.method).toBe("PATCH");
+    });
+
+    it("exposes request and response schemas", () => {
+      expect(profilePatchContract.request).toBe(ProfilePatchRequestSchema);
+      expect(profilePatchContract.response).toBe(ProfilePatchResponseSchema);
+    });
+  });
+});

--- a/packages/contracts/src/auth/profile.ts
+++ b/packages/contracts/src/auth/profile.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+/** Aligns with @myclup/types UserLocalePreference */
+const UserLocalePreferenceSchema = z.object({
+  locale: z.enum(["tr", "en"]),
+  fallbackLocale: z.enum(["tr", "en"]).optional(),
+});
+
+/** Aligns with @myclup/types UserProfile */
+const UserProfileSchema = z.object({
+  userId: z.string(),
+  displayName: z.string(),
+  avatarUrl: z.string().url().nullable(),
+  localePreference: UserLocalePreferenceSchema,
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+/** PATCH request: partial profile fields */
+export const ProfilePatchRequestSchema = z.object({
+  displayName: z.string().min(1).optional(),
+  avatarUrl: z.string().url().nullable().optional(),
+  localePreference: UserLocalePreferenceSchema.optional(),
+});
+
+/** Response schema: full UserProfile */
+export const ProfilePatchResponseSchema = UserProfileSchema;
+
+export type ProfilePatchRequest = z.infer<typeof ProfilePatchRequestSchema>;
+export type ProfilePatchResponse = z.infer<typeof ProfilePatchResponseSchema>;
+
+export const profilePatchContract = {
+  path: "/api/v1/auth/profile",
+  method: "PATCH" as const,
+  request: ProfilePatchRequestSchema,
+  response: ProfilePatchResponseSchema,
+} as const;

--- a/packages/contracts/src/auth/session.test.ts
+++ b/packages/contracts/src/auth/session.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import {
+  SessionRequestSchema,
+  SessionResponseSchema,
+  sessionContract,
+} from "./session";
+
+describe("session contract", () => {
+  describe("SessionRequestSchema", () => {
+    it("validates empty object (GET, no body)", () => {
+      expect(SessionRequestSchema.parse({})).toEqual({});
+    });
+
+    it("strips unknown keys", () => {
+      const result = SessionRequestSchema.safeParse({ foo: "bar" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({});
+      }
+    });
+  });
+
+  describe("SessionResponseSchema", () => {
+    it("validates valid=true", () => {
+      const valid = { valid: true as const };
+      expect(SessionResponseSchema.parse(valid)).toEqual(valid);
+    });
+
+    it("validates valid=false", () => {
+      const invalid = { valid: false as const };
+      expect(SessionResponseSchema.parse(invalid)).toEqual(invalid);
+    });
+
+    it("rejects invalid valid value", () => {
+      const result = SessionResponseSchema.safeParse({ valid: "yes" });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects missing valid field", () => {
+      expect(SessionResponseSchema.safeParse({})).toMatchObject({ success: false });
+    });
+
+    it("strips unknown keys", () => {
+      const result = SessionResponseSchema.safeParse({
+        valid: true,
+        extra: "ignored",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({ valid: true });
+      }
+    });
+  });
+
+  describe("sessionContract", () => {
+    it("has correct path and method", () => {
+      expect(sessionContract.path).toBe("/api/v1/auth/session");
+      expect(sessionContract.method).toBe("GET");
+    });
+
+    it("exposes request and response schemas", () => {
+      expect(sessionContract.request).toBe(SessionRequestSchema);
+      expect(sessionContract.response).toBe(SessionResponseSchema);
+    });
+  });
+});

--- a/packages/contracts/src/auth/session.ts
+++ b/packages/contracts/src/auth/session.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+/** Request schema. session check is typically GET; no body. */
+export const SessionRequestSchema = z.object({});
+
+/** Response schema: session validity */
+export const SessionResponseSchema = z.object({
+  valid: z.boolean(),
+});
+
+export type SessionRequest = z.infer<typeof SessionRequestSchema>;
+export type SessionResponse = z.infer<typeof SessionResponseSchema>;
+
+export const sessionContract = {
+  path: "/api/v1/auth/session",
+  method: "GET" as const,
+  request: SessionRequestSchema,
+  response: SessionResponseSchema,
+} as const;

--- a/packages/contracts/src/auth/whoami.test.ts
+++ b/packages/contracts/src/auth/whoami.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import {
+  WhoamiRequestSchema,
+  WhoamiResponseSchema,
+  whoamiContract,
+} from "./whoami";
+
+describe("whoami contract", () => {
+  describe("WhoamiRequestSchema", () => {
+    it("validates empty object (GET, no body)", () => {
+      expect(WhoamiRequestSchema.parse({})).toEqual({});
+    });
+
+    it("strips unknown keys", () => {
+      const result = WhoamiRequestSchema.safeParse({ foo: "bar" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({});
+      }
+    });
+  });
+
+  describe("WhoamiResponseSchema", () => {
+    const validResponse = {
+      user: {
+        id: "user-uuid",
+        email: "user@example.com",
+        phone: null,
+        createdAt: "2025-03-18T12:00:00.000Z",
+        updatedAt: "2025-03-18T12:00:00.000Z",
+      },
+      profile: {
+        userId: "user-uuid",
+        displayName: "Test User",
+        avatarUrl: "https://example.com/avatar.png",
+        localePreference: { locale: "en" as const, fallbackLocale: "tr" as const },
+        createdAt: "2025-03-18T12:00:00.000Z",
+        updatedAt: "2025-03-18T12:00:00.000Z",
+      },
+      tenantScope: {
+        gymId: "gym-uuid",
+        branchId: "branch-uuid",
+      },
+      roles: [
+        {
+          userId: "user-uuid",
+          role: "gym_staff" as const,
+          gymId: "gym-uuid",
+          branchId: null,
+          grantedAt: "2025-03-18T12:00:00.000Z",
+          grantedBy: "admin-uuid",
+        },
+      ],
+    };
+
+    it("validates correct response", () => {
+      expect(WhoamiResponseSchema.parse(validResponse)).toEqual(validResponse);
+    });
+
+    it("accepts null email and phone on user", () => {
+      const withNulls = {
+        ...validResponse,
+        user: {
+          id: "user-uuid",
+          email: null,
+          phone: null,
+          createdAt: "2025-03-18T12:00:00.000Z",
+          updatedAt: "2025-03-18T12:00:00.000Z",
+        },
+      };
+      expect(WhoamiResponseSchema.parse(withNulls).user.email).toBeNull();
+    });
+
+    it("accepts null avatarUrl on profile", () => {
+      const withNullAvatar = {
+        ...validResponse,
+        profile: {
+          ...validResponse.profile,
+          avatarUrl: null,
+        },
+      };
+      expect(WhoamiResponseSchema.parse(withNullAvatar).profile.avatarUrl).toBeNull();
+    });
+
+    it("accepts null branchId on tenantScope", () => {
+      const gymWide = {
+        ...validResponse,
+        tenantScope: { gymId: "gym-uuid", branchId: null },
+      };
+      expect(WhoamiResponseSchema.parse(gymWide).tenantScope.branchId).toBeNull();
+    });
+
+    it("accepts empty roles array", () => {
+      const noRoles = { ...validResponse, roles: [] };
+      expect(WhoamiResponseSchema.parse(noRoles).roles).toEqual([]);
+    });
+
+    it("rejects invalid email format", () => {
+      const result = WhoamiResponseSchema.safeParse({
+        ...validResponse,
+        user: { ...validResponse.user, email: "not-an-email" },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects invalid role", () => {
+      const result = WhoamiResponseSchema.safeParse({
+        ...validResponse,
+        roles: [{ ...validResponse.roles[0], role: "invalid_role" }],
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("whoamiContract", () => {
+    it("has correct path and method", () => {
+      expect(whoamiContract.path).toBe("/api/v1/auth/whoami");
+      expect(whoamiContract.method).toBe("GET");
+    });
+
+    it("exposes request and response schemas", () => {
+      expect(whoamiContract.request).toBe(WhoamiRequestSchema);
+      expect(whoamiContract.response).toBe(WhoamiResponseSchema);
+    });
+  });
+});

--- a/packages/contracts/src/auth/whoami.ts
+++ b/packages/contracts/src/auth/whoami.ts
@@ -1,0 +1,79 @@
+import { z } from "zod";
+
+/** Aligns with @myclup/types User */
+const UserSchema = z.object({
+  id: z.string(),
+  email: z.string().email().nullable(),
+  phone: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+/** Aligns with @myclup/types UserLocalePreference */
+const UserLocalePreferenceSchema = z.object({
+  locale: z.enum(["tr", "en"]),
+  fallbackLocale: z.enum(["tr", "en"]).optional(),
+});
+
+/** Aligns with @myclup/types UserProfile */
+const UserProfileSchema = z.object({
+  userId: z.string(),
+  displayName: z.string(),
+  avatarUrl: z.string().url().nullable(),
+  localePreference: UserLocalePreferenceSchema,
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+/** Aligns with @myclup/types TenantScope */
+const TenantScopeSchema = z.object({
+  gymId: z.string(),
+  branchId: z.string().nullable(),
+});
+
+/** Aligns with @myclup/types RoleAssignment role union */
+const RoleSchema = z.enum([
+  "platform_admin",
+  "platform_support",
+  "platform_finance",
+  "gym_owner",
+  "gym_manager",
+  "gym_staff",
+  "gym_instructor",
+  "gym_receptionist",
+  "gym_sales",
+  "branch_manager",
+  "branch_instructor",
+  "branch_staff",
+]);
+
+/** Aligns with @myclup/types RoleAssignment */
+const RoleAssignmentSchema = z.object({
+  userId: z.string(),
+  role: RoleSchema,
+  gymId: z.string().nullable(),
+  branchId: z.string().nullable(),
+  grantedAt: z.string(),
+  grantedBy: z.string(),
+});
+
+/** Request schema. whoami is GET; no body. */
+export const WhoamiRequestSchema = z.object({});
+
+/** Response schema: user, profile, tenantScope, roles */
+export const WhoamiResponseSchema = z.object({
+  user: UserSchema,
+  profile: UserProfileSchema,
+  tenantScope: TenantScopeSchema,
+  roles: z.array(RoleAssignmentSchema),
+});
+
+export type WhoamiRequest = z.infer<typeof WhoamiRequestSchema>;
+export type WhoamiResponse = z.infer<typeof WhoamiResponseSchema>;
+
+export const whoamiContract = {
+  path: "/api/v1/auth/whoami",
+  method: "GET" as const,
+  request: WhoamiRequestSchema,
+  response: WhoamiResponseSchema,
+} as const;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -4,4 +4,5 @@
  * Ownership: API schemas, input/output validation, and cross-app contracts.
  * API versioning: /api/v1.
  */
+export * from "./auth";
 export * from "./health";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
 
   packages/contracts:
     dependencies:
+      '@myclup/types':
+        specifier: workspace:*
+        version: link:../types
       zod:
         specifier: ^3.24.0
         version: 3.25.76


### PR DESCRIPTION
Closes #70

Epic: #15

Summary:
- Add packages/contracts/src/auth/ domain folder
- Define Zod schemas for whoami (response with user, profile, tenantScope, roles), session (session validity response), profile (PATCH request and response)
- Reference @myclup/types for User, UserProfile, TenantScope, SupportedLocale
- Follow api-contract-generator pattern: Zod schema → inferred type → contract { path, method, request, response }
- Export from packages/contracts index
- Unit tests for each contract schema

Acceptance Criteria:
- [x] packages/contracts/src/auth/ domain folder
- [x] Zod schemas for whoami, session, profile
- [x] Reference @myclup/types
- [x] Contract pattern with path, method, request, response
- [x] Export from index
- [x] Unit tests for each schema
- [x] pnpm build and typecheck pass

Validation:
- pnpm --filter @myclup/contracts build
- pnpm --filter @myclup/contracts typecheck
- pnpm --filter @myclup/contracts test