### PR TITLE
feat(issue-82): Permission Resolution and Enforcement Helpers

### DIFF
--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -34,8 +34,9 @@
     "generate:types": "echo 'Run: supabase gen types typescript --project-id <id> > src/generated/database.types.ts'"
   },
   "dependencies": {
-    "@supabase/supabase-js": "^2.47.0",
+    "@myclup/types": "workspace:^",
     "@supabase/ssr": "^0.6.0",
+    "@supabase/supabase-js": "^2.47.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/packages/supabase/src/auth/index.ts
+++ b/packages/supabase/src/auth/index.ts
@@ -28,3 +28,11 @@
 export { getSession, type AuthRequest } from './get-session';
 export { getCurrentUser, type CurrentUser, type Profile } from './get-current-user';
 export { createUserScopedClient, type UserScopedSupabaseClient } from './create-user-scoped-client';
+export {
+  resolveTenantScope,
+  checkPermission,
+  requirePermission,
+  ForbiddenError,
+  ROLE_PERMISSIONS,
+  type AnyRole,
+} from './permissions';

--- a/packages/supabase/src/auth/permissions.test.ts
+++ b/packages/supabase/src/auth/permissions.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Unit tests for permission resolution and enforcement helpers.
+ *
+ * Uses mocked Supabase client to test resolveTenantScope, checkPermission,
+ * and requirePermission without live DB access.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  resolveTenantScope,
+  checkPermission,
+  requirePermission,
+  ForbiddenError,
+  ROLE_PERMISSIONS,
+} from './permissions';
+import type { ServerSupabaseClient } from '../client/create-server-client';
+
+// ---------------------------------------------------------------------------
+// Helper: create a mock client that returns specified role rows
+// ---------------------------------------------------------------------------
+
+type MockRoleRow = { role: string; gym_id: string | null; branch_id: string | null };
+type MockStaffRow = { role: string; gym_id: string; branch_id: string | null };
+
+function makeMockClient(
+  roleAssignments: MockRoleRow[],
+  staffAssignments: MockStaffRow[]
+): ServerSupabaseClient {
+  const makeQuery = (rows: unknown[]) => ({
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockResolvedValue({ data: rows, error: null }),
+    }),
+  });
+
+  return {
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === 'user_role_assignments') return makeQuery(roleAssignments);
+      if (table === 'gym_staff') return makeQuery(staffAssignments);
+      return makeQuery([]);
+    }),
+  } as unknown as ServerSupabaseClient;
+}
+
+// ---------------------------------------------------------------------------
+// Tests: ROLE_PERMISSIONS mapping
+// ---------------------------------------------------------------------------
+
+describe('ROLE_PERMISSIONS', () => {
+  it('platform_admin has all permissions', () => {
+    expect(ROLE_PERMISSIONS.platform_admin).toContain('billing:override');
+    expect(ROLE_PERMISSIONS.platform_admin).toContain('roles:write');
+    expect(ROLE_PERMISSIONS.platform_admin).toContain('members:write');
+  });
+
+  it('gym_owner has all gym-level permissions', () => {
+    expect(ROLE_PERMISSIONS.gym_owner).toContain('members:write');
+    expect(ROLE_PERMISSIONS.gym_owner).toContain('billing:override');
+    expect(ROLE_PERMISSIONS.gym_owner).toContain('roles:write');
+  });
+
+  it('gym_receptionist does not have payments:write', () => {
+    expect(ROLE_PERMISSIONS.gym_receptionist).not.toContain('payments:write');
+    expect(ROLE_PERMISSIONS.gym_receptionist).not.toContain('billing:override');
+    expect(ROLE_PERMISSIONS.gym_receptionist).not.toContain('roles:write');
+  });
+
+  it('platform_support has read-only access', () => {
+    expect(ROLE_PERMISSIONS.platform_support).toContain('members:read');
+    expect(ROLE_PERMISSIONS.platform_support).not.toContain('members:write');
+    expect(ROLE_PERMISSIONS.platform_support).not.toContain('billing:override');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: resolveTenantScope
+// ---------------------------------------------------------------------------
+
+describe('resolveTenantScope', () => {
+  const userId = 'user-1';
+  const gymId = 'gym-1';
+  const branchId = 'branch-1';
+
+  it('returns empty array when user has no roles', async () => {
+    const client = makeMockClient([], []);
+    const scopes = await resolveTenantScope(client, userId);
+    expect(scopes).toEqual([]);
+  });
+
+  it('returns gym scope for gym-level role assignment', async () => {
+    const client = makeMockClient([{ role: 'gym_owner', gym_id: gymId, branch_id: null }], []);
+    const scopes = await resolveTenantScope(client, userId);
+    expect(scopes).toHaveLength(1);
+    expect(scopes[0]).toEqual({ gymId, branchId: null });
+  });
+
+  it('returns branch scope for branch-level role assignment', async () => {
+    const client = makeMockClient(
+      [{ role: 'branch_manager', gym_id: gymId, branch_id: branchId }],
+      []
+    );
+    const scopes = await resolveTenantScope(client, userId);
+    expect(scopes).toHaveLength(1);
+    expect(scopes[0]).toEqual({ gymId, branchId });
+  });
+
+  it('filters by gymId when provided', async () => {
+    const client = makeMockClient(
+      [
+        { role: 'gym_owner', gym_id: gymId, branch_id: null },
+        { role: 'gym_manager', gym_id: 'gym-2', branch_id: null },
+      ],
+      []
+    );
+    const scopes = await resolveTenantScope(client, userId, gymId);
+    expect(scopes).toHaveLength(1);
+    expect(scopes[0].gymId).toBe(gymId);
+  });
+
+  it('includes platform_admin scope when gymId filter provided', async () => {
+    const client = makeMockClient([{ role: 'platform_admin', gym_id: null, branch_id: null }], []);
+    const scopes = await resolveTenantScope(client, userId, gymId);
+    expect(scopes).toHaveLength(1);
+    expect(scopes[0]).toEqual({ gymId, branchId: null });
+  });
+
+  it('returns no scopes for platform_admin without gymId filter', async () => {
+    const client = makeMockClient([{ role: 'platform_admin', gym_id: null, branch_id: null }], []);
+    const scopes = await resolveTenantScope(client, userId);
+    expect(scopes).toHaveLength(0);
+  });
+
+  it('deduplicates scopes from user_role_assignments and gym_staff', async () => {
+    const client = makeMockClient(
+      [{ role: 'gym_staff', gym_id: gymId, branch_id: null }],
+      [{ role: 'gym_staff', gym_id: gymId, branch_id: null }]
+    );
+    const scopes = await resolveTenantScope(client, userId);
+    expect(scopes).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: checkPermission
+// ---------------------------------------------------------------------------
+
+describe('checkPermission', () => {
+  const userId = 'user-1';
+  const gymId = 'gym-1';
+
+  it('returns true for gym_owner with members:write in gym scope', async () => {
+    const client = makeMockClient([{ role: 'gym_owner', gym_id: gymId, branch_id: null }], []);
+    const result = await checkPermission(
+      client,
+      userId,
+      { gymId, branchId: null },
+      'members:write'
+    );
+    expect(result).toBe(true);
+  });
+
+  it('returns false for gym_receptionist with payments:write', async () => {
+    const client = makeMockClient(
+      [{ role: 'gym_receptionist', gym_id: gymId, branch_id: null }],
+      []
+    );
+    const result = await checkPermission(
+      client,
+      userId,
+      { gymId, branchId: null },
+      'payments:write'
+    );
+    expect(result).toBe(false);
+  });
+
+  it('returns true for platform_admin in any gym scope', async () => {
+    const client = makeMockClient([{ role: 'platform_admin', gym_id: null, branch_id: null }], []);
+    const result = await checkPermission(
+      client,
+      userId,
+      { gymId: 'any-gym', branchId: null },
+      'billing:override'
+    );
+    expect(result).toBe(true);
+  });
+
+  it('returns false for wrong gym', async () => {
+    const client = makeMockClient(
+      [{ role: 'gym_owner', gym_id: 'gym-other', branch_id: null }],
+      []
+    );
+    const result = await checkPermission(client, userId, { gymId, branchId: null }, 'members:read');
+    expect(result).toBe(false);
+  });
+
+  it('gym-wide role grants permission in branch scope', async () => {
+    const client = makeMockClient([{ role: 'gym_manager', gym_id: gymId, branch_id: null }], []);
+    const result = await checkPermission(
+      client,
+      userId,
+      { gymId, branchId: 'branch-1' },
+      'members:read'
+    );
+    expect(result).toBe(true);
+  });
+
+  it('branch-scoped role does not grant permission in gym-wide scope', async () => {
+    const client = makeMockClient(
+      [{ role: 'branch_manager', gym_id: gymId, branch_id: 'branch-1' }],
+      []
+    );
+    const result = await checkPermission(client, userId, { gymId, branchId: null }, 'members:read');
+    expect(result).toBe(false);
+  });
+
+  it('cross-tenant access is denied', async () => {
+    const client = makeMockClient([{ role: 'gym_owner', gym_id: 'gym-a', branch_id: null }], []);
+    const result = await checkPermission(
+      client,
+      userId,
+      { gymId: 'gym-b', branchId: null },
+      'members:read'
+    );
+    expect(result).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: requirePermission
+// ---------------------------------------------------------------------------
+
+describe('requirePermission', () => {
+  const userId = 'user-1';
+  const gymId = 'gym-1';
+
+  it('does not throw when user has the permission', async () => {
+    const client = makeMockClient([{ role: 'gym_owner', gym_id: gymId, branch_id: null }], []);
+    await expect(
+      requirePermission(client, userId, { gymId, branchId: null }, 'members:write')
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws ForbiddenError when user lacks the permission', async () => {
+    const client = makeMockClient(
+      [{ role: 'gym_receptionist', gym_id: gymId, branch_id: null }],
+      []
+    );
+    await expect(
+      requirePermission(client, userId, { gymId, branchId: null }, 'billing:override')
+    ).rejects.toBeInstanceOf(ForbiddenError);
+  });
+
+  it('ForbiddenError has statusCode 403', async () => {
+    const client = makeMockClient([], []);
+    try {
+      await requirePermission(client, userId, { gymId, branchId: null }, 'members:read');
+      expect.fail('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ForbiddenError);
+      expect((e as ForbiddenError).statusCode).toBe(403);
+    }
+  });
+
+  it('throws ForbiddenError for cross-tenant access attempt', async () => {
+    const client = makeMockClient([{ role: 'gym_owner', gym_id: 'gym-a', branch_id: null }], []);
+    await expect(
+      requirePermission(client, userId, { gymId: 'gym-b', branchId: null }, 'members:read')
+    ).rejects.toBeInstanceOf(ForbiddenError);
+  });
+});

--- a/packages/supabase/src/auth/permissions.ts
+++ b/packages/supabase/src/auth/permissions.ts
@@ -1,0 +1,392 @@
+/**
+ * Permission resolution and enforcement helpers.
+ *
+ * ⚠️ SERVER-ONLY: Use only in BFF routes, API handlers, server actions.
+ * Never call from client apps. Never trust gymId/branchId from the client;
+ * derive from server context using resolveTenantScope.
+ *
+ * Usage sequence:
+ *   1. getSession(req) → validate identity
+ *   2. getCurrentUser(req) → get user + profile
+ *   3. resolveTenantScope(client, userId, gymId?, branchId?) → derive permitted scopes
+ *   4. requirePermission(client, userId, scope, permission) → enforce before writes
+ */
+
+import type {
+  TenantScope,
+  FeaturePermission,
+  PlatformRole,
+  GymRole,
+  BranchRole,
+} from '@myclup/types';
+import type { ServerSupabaseClient } from '../client/create-server-client';
+
+/** All roles that can be assigned. Matches AppRole in database.types.ts. */
+export type AnyRole = PlatformRole | GymRole | BranchRole;
+
+/**
+ * Thrown by requirePermission when the user lacks the required permission.
+ * Callers should map this to a 403 response.
+ */
+export class ForbiddenError extends Error {
+  readonly statusCode = 403;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'ForbiddenError';
+  }
+}
+
+/**
+ * Role → FeaturePermission mapping.
+ *
+ * Platform admins have full access to everything.
+ * Platform support has read-only access to most resources.
+ * Platform finance can read payments and billing.
+ * Gym owners have full access within their gym.
+ * Gym managers can manage members, bookings, classes, and staff.
+ * Gym staff have limited write access.
+ * Gym instructors can manage classes and bookings.
+ * Gym receptionists handle check-in and bookings.
+ * Gym sales manage memberships and payments.
+ * Branch managers have gym-manager level access scoped to their branch.
+ * Branch instructors and staff mirror gym equivalents at branch scope.
+ */
+const ROLE_PERMISSIONS: Record<AnyRole, ReadonlyArray<FeaturePermission>> = {
+  // Platform roles
+  platform_admin: [
+    'members:read',
+    'members:write',
+    'bookings:read',
+    'bookings:write',
+    'payments:read',
+    'payments:write',
+    'chat:read',
+    'chat:write',
+    'classes:read',
+    'classes:write',
+    'reports:read',
+    'settings:write',
+    'roles:write',
+    'billing:override',
+  ],
+  platform_support: [
+    'members:read',
+    'bookings:read',
+    'payments:read',
+    'chat:read',
+    'classes:read',
+    'reports:read',
+  ],
+  platform_finance: [
+    'members:read',
+    'payments:read',
+    'payments:write',
+    'reports:read',
+    'billing:override',
+  ],
+
+  // Gym roles
+  gym_owner: [
+    'members:read',
+    'members:write',
+    'bookings:read',
+    'bookings:write',
+    'payments:read',
+    'payments:write',
+    'chat:read',
+    'chat:write',
+    'classes:read',
+    'classes:write',
+    'reports:read',
+    'settings:write',
+    'roles:write',
+    'billing:override',
+  ],
+  gym_manager: [
+    'members:read',
+    'members:write',
+    'bookings:read',
+    'bookings:write',
+    'payments:read',
+    'chat:read',
+    'chat:write',
+    'classes:read',
+    'classes:write',
+    'reports:read',
+    'settings:write',
+    'roles:write',
+  ],
+  gym_staff: [
+    'members:read',
+    'members:write',
+    'bookings:read',
+    'bookings:write',
+    'payments:read',
+    'chat:read',
+    'chat:write',
+    'classes:read',
+  ],
+  gym_instructor: [
+    'members:read',
+    'bookings:read',
+    'bookings:write',
+    'chat:read',
+    'chat:write',
+    'classes:read',
+    'classes:write',
+  ],
+  gym_receptionist: [
+    'members:read',
+    'bookings:read',
+    'bookings:write',
+    'chat:read',
+    'classes:read',
+  ],
+  gym_sales: [
+    'members:read',
+    'members:write',
+    'payments:read',
+    'payments:write',
+    'chat:read',
+    'bookings:read',
+  ],
+
+  // Branch roles — mirrors gym equivalents, scoped to branch
+  branch_manager: [
+    'members:read',
+    'members:write',
+    'bookings:read',
+    'bookings:write',
+    'payments:read',
+    'chat:read',
+    'chat:write',
+    'classes:read',
+    'classes:write',
+    'reports:read',
+    'settings:write',
+    'roles:write',
+  ],
+  branch_instructor: [
+    'members:read',
+    'bookings:read',
+    'bookings:write',
+    'chat:read',
+    'chat:write',
+    'classes:read',
+    'classes:write',
+  ],
+  branch_staff: [
+    'members:read',
+    'members:write',
+    'bookings:read',
+    'bookings:write',
+    'payments:read',
+    'chat:read',
+    'classes:read',
+  ],
+};
+
+/**
+ * Returns true when a role grants the given permission.
+ */
+function roleHasPermission(role: AnyRole, permission: FeaturePermission): boolean {
+  return (ROLE_PERMISSIONS[role] as ReadonlyArray<string>).includes(permission);
+}
+
+/** A resolved role assignment from user_role_assignments or gym_staff. */
+interface ResolvedRoleAssignment {
+  role: AnyRole;
+  gymId: string | null;
+  branchId: string | null;
+}
+
+/**
+ * Fetch all role assignments for a user from user_role_assignments and gym_staff.
+ * Uses service role client — never expose this to client-side code.
+ */
+async function fetchUserRoles(
+  client: ServerSupabaseClient,
+  userId: string
+): Promise<ResolvedRoleAssignment[]> {
+  const [assignmentsResult, staffResult] = await Promise.all([
+    client.from('user_role_assignments').select('role, gym_id, branch_id').eq('user_id', userId),
+    client.from('gym_staff').select('role, gym_id, branch_id').eq('user_id', userId),
+  ]);
+
+  const assignments: ResolvedRoleAssignment[] = [];
+
+  if (assignmentsResult.data) {
+    for (const row of assignmentsResult.data) {
+      assignments.push({
+        role: row.role as AnyRole,
+        gymId: row.gym_id,
+        branchId: row.branch_id,
+      });
+    }
+  }
+
+  if (staffResult.data) {
+    for (const row of staffResult.data) {
+      // Skip duplicates already captured from user_role_assignments
+      const alreadyExists = assignments.some(
+        (a) => a.role === row.role && a.gymId === row.gym_id && a.branchId === row.branch_id
+      );
+      if (!alreadyExists) {
+        assignments.push({
+          role: row.role as AnyRole,
+          gymId: row.gym_id,
+          branchId: row.branch_id,
+        });
+      }
+    }
+  }
+
+  return assignments;
+}
+
+/**
+ * Resolve the tenant scopes a user is permitted to operate in.
+ *
+ * Queries user_role_assignments and gym_staff to determine which gym/branch
+ * scopes the user has access to. Platform-level roles (platform_admin,
+ * platform_support, platform_finance) with gymId=null are not returned
+ * as TenantScope entries — callers should check those separately via
+ * checkPermission if needed.
+ *
+ * When gymId is provided, only scopes matching that gym are returned.
+ * When branchId is also provided, only scopes matching that branch are returned.
+ *
+ * ⚠️ NEVER trust gymId or branchId from the client; always derive from
+ * server context (e.g. from the authenticated user's JWT claims or URL params
+ * validated server-side).
+ *
+ * @param client - Service role Supabase client
+ * @param userId - Authenticated user's ID (from getSession)
+ * @param gymId - Optional: filter to a specific gym
+ * @param branchId - Optional: filter to a specific branch
+ * @returns Array of tenant scopes the user is permitted to operate in
+ */
+export async function resolveTenantScope(
+  client: ServerSupabaseClient,
+  userId: string,
+  gymId?: string,
+  branchId?: string
+): Promise<TenantScope[]> {
+  const roles = await fetchUserRoles(client, userId);
+  const scopes: TenantScope[] = [];
+
+  for (const assignment of roles) {
+    // Platform-level roles (gymId = null) grant access to all gyms.
+    // Represent as the requested gymId scope when a gymId is provided.
+    if (assignment.gymId === null) {
+      if (gymId) {
+        const scope: TenantScope = { gymId, branchId: branchId ?? null };
+        if (!scopes.some((s) => s.gymId === scope.gymId && s.branchId === scope.branchId)) {
+          scopes.push(scope);
+        }
+      }
+      // If no gymId filter provided, we cannot enumerate all gyms — skip.
+      continue;
+    }
+
+    // Filter by gymId when provided
+    if (gymId && assignment.gymId !== gymId) continue;
+
+    // Filter by branchId when provided
+    if (
+      branchId !== undefined &&
+      assignment.branchId !== null &&
+      assignment.branchId !== branchId
+    ) {
+      continue;
+    }
+
+    const scope: TenantScope = {
+      gymId: assignment.gymId,
+      branchId: branchId ?? assignment.branchId,
+    };
+
+    const alreadyAdded = scopes.some(
+      (s) => s.gymId === scope.gymId && s.branchId === scope.branchId
+    );
+    if (!alreadyAdded) {
+      scopes.push(scope);
+    }
+  }
+
+  return scopes;
+}
+
+/**
+ * Check whether a user has a specific feature permission in the given scope.
+ *
+ * Checks all role assignments for the user and returns true if any role
+ * matching the scope grants the permission. Platform-level roles (gymId = null)
+ * grant the permission in any scope.
+ *
+ * @param client - Service role Supabase client
+ * @param userId - Authenticated user's ID (from getSession)
+ * @param scope - Tenant scope to check (gymId, branchId)
+ * @param permission - Feature permission to verify
+ * @returns true if the user has the permission in the given scope
+ */
+export async function checkPermission(
+  client: ServerSupabaseClient,
+  userId: string,
+  scope: TenantScope,
+  permission: FeaturePermission
+): Promise<boolean> {
+  const roles = await fetchUserRoles(client, userId);
+
+  for (const assignment of roles) {
+    if (!roleHasPermission(assignment.role, permission)) continue;
+
+    // Platform-level role (gymId = null): grants permission in any scope
+    if (assignment.gymId === null) return true;
+
+    // Must match the gym
+    if (assignment.gymId !== scope.gymId) continue;
+
+    // If scope is branch-scoped, role must cover that branch
+    if (scope.branchId !== null) {
+      // Gym-wide role (branchId = null) covers all branches
+      if (assignment.branchId === null) return true;
+      // Branch-scoped role must match
+      if (assignment.branchId === scope.branchId) return true;
+    } else {
+      // Scope is gym-wide — only gym-wide roles apply (branchId = null on assignment)
+      if (assignment.branchId === null) return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Require that a user has a specific feature permission in the given scope.
+ *
+ * Throws ForbiddenError if the user lacks the permission.
+ * Use in write paths before executing any state-modifying operation.
+ *
+ * @param client - Service role Supabase client
+ * @param userId - Authenticated user's ID (from getSession)
+ * @param scope - Tenant scope to enforce (gymId, branchId)
+ * @param permission - Feature permission required
+ * @throws ForbiddenError if permission is denied
+ */
+export async function requirePermission(
+  client: ServerSupabaseClient,
+  userId: string,
+  scope: TenantScope,
+  permission: FeaturePermission
+): Promise<void> {
+  const permitted = await checkPermission(client, userId, scope, permission);
+  if (!permitted) {
+    throw new ForbiddenError(
+      `User ${userId} does not have permission '${permission}' in scope gym:${scope.gymId}/branch:${scope.branchId ?? 'any'}`
+    );
+  }
+}
+
+export { ROLE_PERMISSIONS };

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -23,10 +23,16 @@ export {
   getSession,
   getCurrentUser,
   createUserScopedClient,
+  resolveTenantScope,
+  checkPermission,
+  requirePermission,
+  ForbiddenError,
+  ROLE_PERMISSIONS,
   type AuthRequest,
   type CurrentUser,
   type Profile,
   type UserScopedSupabaseClient,
+  type AnyRole,
 } from './auth/index';
 
 export type { Database, Json } from './generated/database.types';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,1 +1,5 @@
-export * from "./locale";
+export * from './locale';
+export * from './user';
+export * from './tenant';
+export * from './role';
+export * from './member';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,9 @@ importers:
 
   packages/supabase:
     dependencies:
+      '@myclup/types':
+        specifier: workspace:^
+        version: link:../types
       '@supabase/ssr':
         specifier: ^0.6.0
         version: 0.6.1(@supabase/supabase-js@2.99.2)


### PR DESCRIPTION
Closes #82

Epic: #15

## Summary

Implements Task 15.5: Permission Resolution and Enforcement Helpers for Epic #15 Authentication, Identity, Tenant Model, and Permissions.

- `resolveTenantScope(client, userId, gymId?, branchId?)` — queries `user_role_assignments` and `gym_staff` to derive permitted `TenantScope[]`; never trusts client-supplied IDs
- `checkPermission(client, userId, scope, permission)` — boolean check; platform-level roles grant access to any scope; cross-tenant access returns false
- `requirePermission(client, userId, scope, permission)` — throws `ForbiddenError` (statusCode 403) on denial; for use in all write paths
- `ROLE_PERMISSIONS` — complete role→`FeaturePermission` mapping for all `PlatformRole`, `GymRole`, and `BranchRole` values
- `ForbiddenError` class with `statusCode = 403` for BFF route error handling

Also:
- Exports all domain types from `@myclup/types` (user, tenant, role, member were previously unexported from index)
- Adds `Relationships: []` to all tables in `database.types.ts` (required by `@supabase/supabase-js@2.99.2` `GenericTable` constraint)
- Fixes `getCurrentUser` profile type inference with explicit cast

## Acceptance Criteria

- [x] `resolveTenantScope` returns valid scope(s) for user; filters by gymId/branchId when provided
- [x] `checkPermission` returns boolean; respects role→permission mapping
- [x] `requirePermission` throws `ForbiddenError` when check fails
- [x] Role→permission mapping documented (ROLE_PERMISSIONS constant)
- [x] Platform admin has full access; gym/branch roles scoped per assignment
- [x] `pnpm typecheck` passes
- [x] Unit tests: 22 tests covering all three helpers, cross-tenant denial, branch scope logic

## Validation

```
pnpm --filter @myclup/supabase typecheck  # passes
pnpm --filter @myclup/supabase lint       # passes
pnpm --filter @myclup/supabase test       # 37 tests pass (22 permission tests)
```

## Security Notes

- `resolveTenantScope` derives scope from DB assignments only — client-supplied `gymId`/`branchId` must be validated by the caller before use
- Cross-tenant access is explicitly tested and denied
- Branch-scoped roles cannot escalate to gym-wide scope