### PR TITLE
feat(issue-75): api-client Auth Methods with Injectable Auth Headers

### DIFF
--- a/packages/api-client/src/auth.test.ts
+++ b/packages/api-client/src/auth.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Unit tests for the auth API namespace.
+ *
+ * Tests that auth methods call the correct contracts and parse responses.
+ * Uses mocked fetch to avoid live network calls.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createApi, ApiError } from './index';
+import {
+  WhoamiResponseSchema,
+  SessionResponseSchema,
+  ProfilePatchResponseSchema,
+} from '@myclup/contracts/auth';
+
+const MOCK_WHOAMI = {
+  user: {
+    id: 'user-1',
+    email: 'test@example.com',
+    phone: null,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+  },
+  profile: {
+    userId: 'user-1',
+    displayName: 'Test User',
+    avatarUrl: null,
+    localePreference: { locale: 'tr' as const },
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+  },
+  tenantScope: { gymId: 'gym-1', branchId: null },
+  roles: [
+    {
+      userId: 'user-1',
+      role: 'gym_owner' as const,
+      gymId: 'gym-1',
+      branchId: null,
+      grantedAt: '2024-01-01T00:00:00Z',
+      grantedBy: 'admin',
+    },
+  ],
+};
+
+const MOCK_SESSION_VALID = { valid: true };
+
+const MOCK_PROFILE = {
+  userId: 'user-1',
+  displayName: 'Updated Name',
+  avatarUrl: null,
+  localePreference: { locale: 'en' as const },
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-02T00:00:00Z',
+};
+
+function mockFetch(status: number, body: unknown): typeof fetch {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : String(status),
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  }) as unknown as typeof fetch;
+}
+
+describe('auth.whoami', () => {
+  it('calls GET /api/v1/auth/whoami with auth headers and returns parsed response', async () => {
+    const mockFetchFn = mockFetch(200, MOCK_WHOAMI);
+    const authHeaders = { Authorization: 'Bearer test-token' };
+    const getAuthHeaders = vi.fn().mockResolvedValue(authHeaders);
+
+    const api = createApi({
+      baseUrl: 'http://localhost:3001',
+      fetch: mockFetchFn,
+      getAuthHeaders,
+    });
+
+    const result = await api.auth.whoami();
+
+    expect(getAuthHeaders).toHaveBeenCalledOnce();
+    expect(mockFetchFn).toHaveBeenCalledWith(
+      'http://localhost:3001/api/v1/auth/whoami',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({ Authorization: 'Bearer test-token' }),
+      })
+    );
+    expect(WhoamiResponseSchema.safeParse(result).success).toBe(true);
+    expect(result.user.id).toBe('user-1');
+    expect(result.tenantScope.gymId).toBe('gym-1');
+  });
+
+  it('throws ApiError with status 401 when unauthenticated', async () => {
+    const mockFetchFn = mockFetch(401, { error: 'unauthorized' });
+    const api = createApi({ baseUrl: 'http://localhost:3001', fetch: mockFetchFn });
+
+    await expect(api.auth.whoami()).rejects.toBeInstanceOf(ApiError);
+    await expect(api.auth.whoami()).rejects.toMatchObject({ status: 401 });
+  });
+});
+
+describe('auth.getSession', () => {
+  it('calls GET /api/v1/auth/session and returns valid:true when authenticated', async () => {
+    const api = createApi({
+      baseUrl: 'http://localhost:3001',
+      fetch: mockFetch(200, MOCK_SESSION_VALID),
+    });
+
+    const result = await api.auth.getSession();
+
+    expect(SessionResponseSchema.safeParse(result).success).toBe(true);
+    expect(result.valid).toBe(true);
+  });
+
+  it('returns valid:false when session is absent', async () => {
+    const api = createApi({
+      baseUrl: 'http://localhost:3001',
+      fetch: mockFetch(200, { valid: false }),
+    });
+
+    const result = await api.auth.getSession();
+
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe('auth.updateProfile', () => {
+  it('calls PATCH /api/v1/auth/profile with validated body and returns updated profile', async () => {
+    const mockFetchFn = mockFetch(200, MOCK_PROFILE);
+    const api = createApi({
+      baseUrl: 'http://localhost:3001',
+      fetch: mockFetchFn,
+      getAuthHeaders: async () => ({ Authorization: 'Bearer test-token' }),
+    });
+
+    const input = { displayName: 'Updated Name', localePreference: { locale: 'en' as const } };
+    const result = await api.auth.updateProfile(input);
+
+    expect(mockFetchFn).toHaveBeenCalledWith(
+      'http://localhost:3001/api/v1/auth/profile',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify(input),
+      })
+    );
+    expect(ProfilePatchResponseSchema.safeParse(result).success).toBe(true);
+    expect(result.displayName).toBe('Updated Name');
+  });
+
+  it('throws ApiError with status 401 when unauthenticated', async () => {
+    const api = createApi({
+      baseUrl: 'http://localhost:3001',
+      fetch: mockFetch(401, { error: 'unauthorized' }),
+    });
+
+    await expect(api.auth.updateProfile({ displayName: 'Test' })).rejects.toMatchObject({
+      status: 401,
+    });
+  });
+});
+
+describe('getAuthHeaders injection', () => {
+  it('merges getAuthHeaders result into every request', async () => {
+    const mockFetchFn = mockFetch(200, MOCK_SESSION_VALID);
+    const getAuthHeaders = vi.fn().mockResolvedValue({ Authorization: 'Bearer dynamic-token' });
+
+    const api = createApi({
+      baseUrl: 'http://localhost:3001',
+      fetch: mockFetchFn,
+      getAuthHeaders,
+    });
+
+    await api.auth.getSession();
+
+    const callArgs = (mockFetchFn as ReturnType<typeof vi.fn>).mock.calls[0];
+    const init = callArgs[1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer dynamic-token');
+    expect(getAuthHeaders).toHaveBeenCalledOnce();
+  });
+
+  it('auth headers take precedence over static headers', async () => {
+    const mockFetchFn = mockFetch(200, MOCK_SESSION_VALID);
+
+    const api = createApi({
+      baseUrl: 'http://localhost:3001',
+      fetch: mockFetchFn,
+      headers: { Authorization: 'Bearer static-token', 'X-Custom': 'value' },
+      getAuthHeaders: async () => ({ Authorization: 'Bearer dynamic-token' }),
+    });
+
+    await api.auth.getSession();
+
+    const callArgs = (mockFetchFn as ReturnType<typeof vi.fn>).mock.calls[0];
+    const init = callArgs[1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer dynamic-token');
+    expect(headers['X-Custom']).toBe('value');
+  });
+});

--- a/packages/api-client/src/auth.ts
+++ b/packages/api-client/src/auth.ts
@@ -1,0 +1,81 @@
+/**
+ * Auth API namespace for the shared api-client.
+ *
+ * Provides typed methods for whoami, session, and profile update.
+ * Auth token must be injected via getAuthHeaders in ApiClientConfig.
+ *
+ * Web configuration:
+ *   const api = createApi({
+ *     baseUrl: process.env.NEXT_PUBLIC_API_URL,
+ *     getAuthHeaders: async () => {
+ *       const { data } = await supabase.auth.getSession();
+ *       const token = data.session?.access_token;
+ *       return token ? { Authorization: `Bearer ${token}` } : {};
+ *     },
+ *   });
+ *
+ * Mobile configuration:
+ *   const api = createApi({
+ *     baseUrl: process.env.EXPO_PUBLIC_API_URL,
+ *     getAuthHeaders: async () => {
+ *       const session = await getLocalSession();
+ *       return session?.access_token
+ *         ? { Authorization: `Bearer ${session.access_token}` }
+ *         : {};
+ *     },
+ *   });
+ */
+
+import type {
+  WhoamiResponse,
+  SessionResponse,
+  ProfilePatchRequest,
+  ProfilePatchResponse,
+} from '@myclup/contracts/auth';
+import { whoamiContract, sessionContract, profilePatchContract } from '@myclup/contracts/auth';
+import type { ApiContract } from './client';
+
+type RequestFn = <T>(contract: ApiContract<unknown, T>, requestData?: unknown) => Promise<T>;
+
+/**
+ * Creates the auth API namespace with typed methods.
+ * All responses are validated against their contract schemas.
+ */
+export function createAuthApi(request: RequestFn) {
+  return {
+    /**
+     * GET /api/v1/auth/whoami
+     *
+     * Returns the authenticated user, profile, primary tenant scope, and role assignments.
+     * Throws ApiError with status 401 when unauthenticated.
+     */
+    async whoami(): Promise<WhoamiResponse> {
+      return request(whoamiContract as ApiContract<unknown, WhoamiResponse>);
+    },
+
+    /**
+     * GET /api/v1/auth/session
+     *
+     * Returns session validity. Does not throw on unauthenticated — returns { valid: false }.
+     */
+    async getSession(): Promise<SessionResponse> {
+      return request(sessionContract as ApiContract<unknown, SessionResponse>);
+    },
+
+    /**
+     * PATCH /api/v1/auth/profile
+     *
+     * Updates the authenticated user's profile fields.
+     * Throws ApiError with status 401 when unauthenticated.
+     * Throws ApiError with status 400 when input validation fails.
+     *
+     * @param input - Fields to update (all optional; only provided fields are updated)
+     */
+    async updateProfile(input: ProfilePatchRequest): Promise<ProfilePatchResponse> {
+      return request(
+        profilePatchContract as ApiContract<ProfilePatchRequest, ProfilePatchResponse>,
+        input
+      );
+    },
+  };
+}

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -12,8 +12,28 @@ export type ApiContract<TRequest = unknown, TResponse = unknown> = {
 export type ApiClientConfig = {
   /** Base URL for all requests (e.g. https://api.example.com). Trailing slash is normalized. */
   baseUrl: string;
-  /** Optional headers to inject (e.g. Authorization). Applied to every request. */
+  /** Optional static headers to inject. Applied to every request. */
   headers?: Record<string, string>;
+  /**
+   * Optional async function that returns auth headers for each request.
+   * Use this for dynamic token injection (Supabase session on web, access_token on mobile).
+   *
+   * Web example:
+   *   getAuthHeaders: async () => {
+   *     const { data } = await supabase.auth.getSession();
+   *     const token = data.session?.access_token;
+   *     return token ? { Authorization: `Bearer ${token}` } : {};
+   *   }
+   *
+   * Mobile example:
+   *   getAuthHeaders: async () => {
+   *     const session = await getLocalSession();
+   *     return session?.access_token
+   *       ? { Authorization: `Bearer ${session.access_token}` }
+   *       : {};
+   *   }
+   */
+  getAuthHeaders?: () => Promise<Record<string, string>> | Record<string, string>;
   /** Custom fetch implementation (for testing or custom behavior). */
   fetch?: typeof fetch;
 };
@@ -36,18 +56,22 @@ export class ApiError extends Error {
  */
 export function createApiClient(config: ApiClientConfig) {
   const baseUrl = config.baseUrl.replace(/\/$/, '');
-  const headers = config.headers ?? {};
+  const staticHeaders = config.headers ?? {};
   const doFetch = config.fetch ?? fetch;
 
   /**
    * Performs a contract-based request. Fetches the endpoint, parses the response
    * with contract.response.parse(), and returns the typed result.
+   *
+   * When getAuthHeaders is configured, it is called before each request and its
+   * result is merged with static headers (auth headers take precedence).
    */
   async function request<T>(contract: ApiContract<unknown, T>, requestData?: unknown): Promise<T> {
+    const authHeaders = config.getAuthHeaders ? await config.getAuthHeaders() : {};
     const url = `${baseUrl}${contract.path}`;
     const init: RequestInit = {
       method: contract.method,
-      headers: { 'Content-Type': 'application/json', ...headers },
+      headers: { 'Content-Type': 'application/json', ...staticHeaders, ...authHeaders },
     };
 
     if (requestData !== undefined && contract.method !== 'GET') {

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -3,13 +3,32 @@
  *
  * Web and mobile apps must use this package for BFF calls. No app may introduce
  * a second network client.
+ *
+ * Auth configuration:
+ *   const api = createApi({
+ *     baseUrl: process.env.NEXT_PUBLIC_API_URL,
+ *     getAuthHeaders: async () => {
+ *       const { data } = await supabase.auth.getSession();
+ *       const token = data.session?.access_token;
+ *       return token ? { Authorization: `Bearer ${token}` } : {};
+ *     },
+ *   });
+ *   const user = await api.auth.whoami();
  */
 export { createApiClient, ApiError, type ApiClientConfig, type ApiContract } from './client';
 export { createHealthApi } from './health';
+export { createAuthApi } from './auth';
 export type { PingResponse } from '@myclup/contracts/health';
+export type {
+  WhoamiResponse,
+  SessionResponse,
+  ProfilePatchRequest,
+  ProfilePatchResponse,
+} from '@myclup/contracts/auth';
 
 import { createApiClient } from './client';
 import { createHealthApi } from './health';
+import { createAuthApi } from './auth';
 import type { ApiClientConfig } from './client';
 
 /**
@@ -17,12 +36,17 @@ import type { ApiClientConfig } from './client';
  * Use this in web and mobile apps to get typed domain methods.
  *
  * @example
- * const api = createApi({ baseUrl: "https://api.example.com" });
+ * const api = createApi({
+ *   baseUrl: "https://api.example.com",
+ *   getAuthHeaders: async () => ({ Authorization: `Bearer ${token}` }),
+ * });
  * const result = await api.health.ping();
+ * const user = await api.auth.whoami();
  */
 export function createApi(config: ApiClientConfig) {
   const client = createApiClient(config);
   return {
     health: createHealthApi(client.request),
+    auth: createAuthApi(client.request),
   };
 }


### PR DESCRIPTION
Closes #75

Epic: #15

## Summary

Implements Task 15.8: api-client Auth Methods for Epic #15.

**Depends on #86** (Task 15.7: Auth API Routes) — base branch is `feat/issue-74-auth-api-routes`.

### Changes to `packages/api-client`

#### New: `auth` namespace (`src/auth.ts`)

| Method | Contract | Description |
|--------|----------|-------------|
| `auth.whoami()` | `whoamiContract` | GET /api/v1/auth/whoami — throws ApiError 401 when unauthenticated |
| `auth.getSession()` | `sessionContract` | GET /api/v1/auth/session — returns `{ valid: boolean }` |
| `auth.updateProfile(input)` | `profilePatchContract` | PATCH /api/v1/auth/profile — throws 401/400 on failure |

#### Updated: `ApiClientConfig` and `createApiClient`

Added `getAuthHeaders?: () => Promise<Record<string, string>> | Record<string, string>` for dynamic per-request token injection. Auth headers take precedence over static `headers`.

**Web usage:**
```ts
const api = createApi({
  baseUrl: process.env.NEXT_PUBLIC_API_URL,
  getAuthHeaders: async () => {
    const { data } = await supabase.auth.getSession();
    const token = data.session?.access_token;
    return token ? { Authorization: `Bearer ${token}` } : {};
  },
});
```

**Mobile usage:**
```ts
const api = createApi({
  baseUrl: process.env.EXPO_PUBLIC_API_URL,
  getAuthHeaders: async () => {
    const session = await getLocalSession();
    return session?.access_token
      ? { Authorization: `Bearer ${session.access_token}` }
      : {};
  },
});
```

## Acceptance Criteria

- [x] auth.whoami() calls GET /api/v1/auth/whoami with auth headers
- [x] auth.getSession() calls GET /api/v1/auth/session
- [x] auth.updateProfile(input) calls PATCH with validated input
- [x] Client supports injectable auth headers via `getAuthHeaders`
- [x] Responses parsed with contract.response.parse()
- [x] `pnpm typecheck` and `pnpm build` pass

## Validation

```
pnpm --filter @myclup/api-client typecheck  # passes
pnpm --filter @myclup/api-client lint       # passes
pnpm --filter @myclup/api-client test       # 12 tests pass (8 auth + 4 health)
```