### PR TITLE
feat(issue-98): Chat contracts (Conversation, Message, Receipt, Assignment)

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -20,6 +20,10 @@
     "./common": {
       "types": "./dist/common/index.d.ts",
       "default": "./dist/common/index.js"
+    },
+    "./chat": {
+      "types": "./dist/chat/index.d.ts",
+      "default": "./dist/chat/index.js"
     }
   },
   "scripts": {

--- a/packages/contracts/src/chat/chat.test.ts
+++ b/packages/contracts/src/chat/chat.test.ts
@@ -1,0 +1,325 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ConversationTypeSchema,
+  ConversationSchema,
+  ConversationParticipantSchema,
+  MessageSchema,
+  MessageAttachmentSchema,
+  MessageReceiptSchema,
+  ConversationAssignmentSchema,
+  TypingStateSchema,
+  CreateConversationInputSchema,
+  CreateMessageInputSchema,
+  MessageReceiptUpdateSchema,
+  AssignConversationInputSchema,
+  CursorPageParamsSchema,
+  ListConversationsResponseSchema,
+  ListMessagesResponseSchema,
+  GetConversationResponseSchema,
+  listConversationsContract,
+  getConversationContract,
+  createConversationContract,
+  listMessagesContract,
+  sendMessageContract,
+  markReadContract,
+  assignConversationContract,
+} from './index';
+
+const validUuid = '550e8400-e29b-41d4-a716-446655440000';
+const validDatetime = '2025-03-19T12:00:00.000Z';
+
+describe('chat contracts', () => {
+  describe('ConversationTypeSchema', () => {
+    it('accepts all valid conversation types', () => {
+      const types = [
+        'direct',
+        'support',
+        'instructor',
+        'group',
+        'broadcast',
+        'internal_staff',
+      ] as const;
+      for (const t of types) {
+        expect(ConversationTypeSchema.parse(t)).toBe(t);
+      }
+    });
+
+    it('rejects invalid type', () => {
+      expect(ConversationTypeSchema.safeParse('invalid')).toEqual({
+        success: false,
+        error: expect.any(Object),
+      });
+    });
+  });
+
+  describe('CreateMessageInputSchema (idempotency via dedupeKey)', () => {
+    it('requires dedupeKey', () => {
+      const result = CreateMessageInputSchema.safeParse({ content: 'hi' });
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts valid input with dedupeKey', () => {
+      const input = { content: 'Hello', dedupeKey: 'client-msg-123' };
+      expect(CreateMessageInputSchema.parse(input)).toEqual(input);
+    });
+
+    it('rejects empty dedupeKey', () => {
+      const result = CreateMessageInputSchema.safeParse({ content: 'hi', dedupeKey: '' });
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts optional attachmentPaths', () => {
+      const input = {
+        content: 'File',
+        dedupeKey: 'msg-456',
+        attachmentPaths: ['path/to/file.png'],
+      };
+      expect(CreateMessageInputSchema.parse(input).attachmentPaths).toEqual(['path/to/file.png']);
+    });
+  });
+
+  describe('CreateConversationInputSchema', () => {
+    it('validates minimal input', () => {
+      const input = {
+        gymId: validUuid,
+        type: 'direct' as const,
+        participantUserIds: [validUuid],
+      };
+      expect(CreateConversationInputSchema.parse(input)).toEqual(input);
+    });
+
+    it('rejects empty participantUserIds', () => {
+      expect(
+        CreateConversationInputSchema.safeParse({
+          gymId: validUuid,
+          type: 'direct',
+          participantUserIds: [],
+        })
+      ).toMatchObject({ success: false });
+    });
+  });
+
+  describe('MessageReceiptUpdateSchema', () => {
+    it('accepts optional readAt', () => {
+      expect(MessageReceiptUpdateSchema.parse({})).toEqual({});
+      expect(MessageReceiptUpdateSchema.parse({ readAt: validDatetime }).readAt).toBe(
+        validDatetime
+      );
+    });
+  });
+
+  describe('AssignConversationInputSchema', () => {
+    it('validates assignedToUserId', () => {
+      expect(AssignConversationInputSchema.parse({ assignedToUserId: validUuid })).toEqual({
+        assignedToUserId: validUuid,
+      });
+    });
+
+    it('rejects invalid uuid', () => {
+      expect(
+        AssignConversationInputSchema.safeParse({ assignedToUserId: 'not-uuid' })
+      ).toMatchObject({
+        success: false,
+      });
+    });
+  });
+
+  describe('CursorPageParamsSchema', () => {
+    it('accepts cursor and limit', () => {
+      expect(CursorPageParamsSchema.parse({ cursor: 'abc', limit: 10 })).toEqual({
+        cursor: 'abc',
+        limit: 10,
+      });
+    });
+
+    it('defaults limit to 20', () => {
+      expect(CursorPageParamsSchema.parse({})).toEqual({ limit: 20 });
+    });
+
+    it('rejects limit > 100', () => {
+      expect(CursorPageParamsSchema.safeParse({ limit: 101 })).toMatchObject({ success: false });
+    });
+  });
+
+  describe('ListConversationsResponseSchema', () => {
+    const validConversation = {
+      id: validUuid,
+      gymId: validUuid,
+      branchId: validUuid,
+      type: 'direct' as const,
+      metadata: {},
+      createdAt: validDatetime,
+      updatedAt: validDatetime,
+    };
+
+    it('validates cursor-paginated result', () => {
+      const result = { items: [validConversation], nextCursor: 'cursor-123' };
+      expect(ListConversationsResponseSchema.parse(result)).toEqual(result);
+    });
+
+    it('accepts null nextCursor for last page', () => {
+      const result = { items: [], nextCursor: null };
+      expect(ListConversationsResponseSchema.parse(result)).toEqual(result);
+    });
+  });
+
+  describe('ListMessagesResponseSchema', () => {
+    const validMessage = {
+      id: validUuid,
+      conversationId: validUuid,
+      senderId: validUuid,
+      content: 'Hi',
+      dedupeKey: null,
+      createdAt: validDatetime,
+    };
+
+    it('validates cursor-paginated messages', () => {
+      const result = { items: [validMessage], nextCursor: null };
+      expect(ListMessagesResponseSchema.parse(result)).toEqual(result);
+    });
+  });
+
+  describe('GetConversationResponseSchema', () => {
+    it('validates conversation with participants and assignment', () => {
+      const response = {
+        id: validUuid,
+        gymId: validUuid,
+        branchId: null,
+        type: 'direct' as const,
+        metadata: {},
+        createdAt: validDatetime,
+        updatedAt: validDatetime,
+        participants: [
+          {
+            conversationId: validUuid,
+            userId: validUuid,
+            role: 'member',
+            joinedAt: validDatetime,
+          },
+        ],
+        assignment: null,
+      };
+      expect(GetConversationResponseSchema.parse(response)).toEqual(response);
+    });
+  });
+
+  describe('Entity schemas', () => {
+    it('ConversationSchema validates', () => {
+      expect(
+        ConversationSchema.parse({
+          id: validUuid,
+          gymId: validUuid,
+          branchId: null,
+          type: 'direct',
+          metadata: {},
+          createdAt: validDatetime,
+          updatedAt: validDatetime,
+        })
+      ).toBeDefined();
+    });
+
+    it('ConversationParticipantSchema validates', () => {
+      expect(
+        ConversationParticipantSchema.parse({
+          conversationId: validUuid,
+          userId: validUuid,
+          role: 'member',
+          joinedAt: validDatetime,
+        })
+      ).toBeDefined();
+    });
+
+    it('MessageSchema validates', () => {
+      expect(
+        MessageSchema.parse({
+          id: validUuid,
+          conversationId: validUuid,
+          senderId: validUuid,
+          content: 'Hi',
+          dedupeKey: null,
+          createdAt: validDatetime,
+        })
+      ).toBeDefined();
+    });
+
+    it('MessageAttachmentSchema validates', () => {
+      expect(
+        MessageAttachmentSchema.parse({
+          id: validUuid,
+          messageId: validUuid,
+          storagePath: 'bucket/path',
+          mimeType: 'image/png',
+          filename: 'img.png',
+          createdAt: validDatetime,
+        })
+      ).toBeDefined();
+    });
+
+    it('MessageReceiptSchema validates', () => {
+      expect(
+        MessageReceiptSchema.parse({
+          messageId: validUuid,
+          participantId: validUuid,
+          readAt: validDatetime,
+        })
+      ).toBeDefined();
+    });
+
+    it('ConversationAssignmentSchema validates', () => {
+      expect(
+        ConversationAssignmentSchema.parse({
+          id: validUuid,
+          conversationId: validUuid,
+          assignedToUserId: validUuid,
+          assignedAt: validDatetime,
+          assignedByUserId: null,
+          unassignedAt: null,
+        })
+      ).toBeDefined();
+    });
+
+    it('TypingStateSchema validates', () => {
+      expect(
+        TypingStateSchema.parse({
+          userId: validUuid,
+          conversationId: validUuid,
+          isTyping: true,
+        })
+      ).toBeDefined();
+    });
+  });
+
+  describe('contract objects', () => {
+    it('listConversationsContract has correct path', () => {
+      expect(listConversationsContract.path).toBe('/api/v1/chat/conversations');
+      expect(listConversationsContract.method).toBe('GET');
+    });
+
+    it('getConversationContract has :id placeholder', () => {
+      expect(getConversationContract.path).toBe('/api/v1/chat/conversations/:id');
+    });
+
+    it('createConversationContract uses POST', () => {
+      expect(createConversationContract.path).toBe('/api/v1/chat/conversations');
+      expect(createConversationContract.method).toBe('POST');
+    });
+
+    it('sendMessageContract uses CreateMessageInput', () => {
+      expect(sendMessageContract.request).toBe(CreateMessageInputSchema);
+    });
+
+    it('listMessagesContract supports cursor pagination', () => {
+      expect(listMessagesContract.request).toBeDefined();
+    });
+
+    it('markReadContract uses PATCH on message receipts', () => {
+      expect(markReadContract.path).toBe('/api/v1/chat/messages/:id/receipts');
+      expect(markReadContract.method).toBe('PATCH');
+    });
+
+    it('assignConversationContract uses POST', () => {
+      expect(assignConversationContract.path).toBe('/api/v1/chat/conversations/:id/assign');
+      expect(assignConversationContract.method).toBe('POST');
+    });
+  });
+});

--- a/packages/contracts/src/chat/contracts.ts
+++ b/packages/contracts/src/chat/contracts.ts
@@ -1,0 +1,90 @@
+/**
+ * Chat API contract definitions.
+ *
+ * Contracts for: list conversations, get conversation, create conversation,
+ * list messages (cursor pagination), send message, mark read, assign conversation.
+ *
+ * @see docs/07-technical-plan.md §7.3
+ * @see docs/epic-17-task-decomposition.md Task 17.2
+ */
+
+import { z } from 'zod';
+import {
+  AssignConversationInputSchema,
+  ConversationAssignmentSchema,
+  ConversationSchema,
+  CreateConversationInputSchema,
+  CreateMessageInputSchema,
+  CursorPageParamsSchema,
+  GetConversationResponseSchema,
+  ListConversationsResponseSchema,
+  ListMessagesResponseSchema,
+  MessageReceiptUpdateSchema,
+  MessageSchema,
+} from './schemas';
+
+/** Empty request for GET by path param. */
+const GetByIdRequestSchema = z.object({});
+
+// --- List conversations ---
+
+export const listConversationsContract = {
+  path: '/api/v1/chat/conversations',
+  method: 'GET' as const,
+  request: CursorPageParamsSchema,
+  response: ListConversationsResponseSchema,
+} as const;
+
+// --- Get conversation ---
+
+export const getConversationContract = {
+  path: '/api/v1/chat/conversations/:id',
+  method: 'GET' as const,
+  request: GetByIdRequestSchema,
+  response: GetConversationResponseSchema,
+} as const;
+
+// --- Create conversation ---
+
+export const createConversationContract = {
+  path: '/api/v1/chat/conversations',
+  method: 'POST' as const,
+  request: CreateConversationInputSchema,
+  response: ConversationSchema,
+} as const;
+
+// --- List messages (cursor pagination) ---
+
+export const listMessagesContract = {
+  path: '/api/v1/chat/conversations/:id/messages',
+  method: 'GET' as const,
+  request: CursorPageParamsSchema,
+  response: ListMessagesResponseSchema,
+} as const;
+
+// --- Send message (idempotent via dedupe_key) ---
+
+export const sendMessageContract = {
+  path: '/api/v1/chat/conversations/:id/messages',
+  method: 'POST' as const,
+  request: CreateMessageInputSchema,
+  response: MessageSchema,
+} as const;
+
+// --- Mark read ---
+
+export const markReadContract = {
+  path: '/api/v1/chat/messages/:id/receipts',
+  method: 'PATCH' as const,
+  request: MessageReceiptUpdateSchema,
+  response: MessageReceiptUpdateSchema,
+} as const;
+
+// --- Assign conversation ---
+
+export const assignConversationContract = {
+  path: '/api/v1/chat/conversations/:id/assign',
+  method: 'POST' as const,
+  request: AssignConversationInputSchema,
+  response: ConversationAssignmentSchema,
+} as const;

--- a/packages/contracts/src/chat/index.ts
+++ b/packages/contracts/src/chat/index.ts
@@ -1,0 +1,58 @@
+/**
+ * @myclup/contracts/chat — Chat API contracts.
+ *
+ * Entities: Conversation, ConversationParticipant, Message, MessageAttachment,
+ * MessageReceipt, ConversationAssignment, TypingState.
+ *
+ * @see docs/07-technical-plan.md §7.3
+ * @see docs/epic-17-task-decomposition.md Task 17.2
+ */
+
+export {
+  AssignConversationInputSchema,
+  ConversationAssignmentSchema,
+  ConversationMetadataSchema,
+  ConversationParticipantSchema,
+  ConversationSchema,
+  ConversationTypeSchema,
+  CreateConversationInputSchema,
+  CreateMessageInputSchema,
+  CursorPageParamsSchema,
+  GetConversationResponseSchema,
+  ListConversationsResponseSchema,
+  ListMessagesResponseSchema,
+  MessageAttachmentSchema,
+  MessageReceiptSchema,
+  MessageReceiptUpdateSchema,
+  MessageSchema,
+  TypingStateSchema,
+  createCursorPageResultSchema,
+} from './schemas';
+export type {
+  AssignConversationInput,
+  Conversation,
+  ConversationAssignment,
+  ConversationMetadata,
+  ConversationParticipant,
+  ConversationType,
+  CreateConversationInput,
+  CreateMessageInput,
+  CursorPageParams,
+  CursorPageResult,
+  GetConversationResponse,
+  Message,
+  MessageAttachment,
+  MessageReceipt,
+  MessageReceiptUpdate,
+  TypingState,
+} from './schemas';
+
+export {
+  assignConversationContract,
+  createConversationContract,
+  getConversationContract,
+  listConversationsContract,
+  listMessagesContract,
+  markReadContract,
+  sendMessageContract,
+} from './contracts';

--- a/packages/contracts/src/chat/schemas.ts
+++ b/packages/contracts/src/chat/schemas.ts
@@ -1,0 +1,153 @@
+/**
+ * Chat entity schemas and input schemas.
+ * Aligns with packages/supabase chat tables (Task 17.1).
+ */
+import { z } from 'zod';
+
+/** Aligns with DB conversation_type enum. */
+export const ConversationTypeSchema = z.enum([
+  'direct',
+  'support',
+  'instructor',
+  'group',
+  'broadcast',
+  'internal_staff',
+]);
+export type ConversationType = z.infer<typeof ConversationTypeSchema>;
+
+/** Conversation metadata (jsonb). */
+export const ConversationMetadataSchema = z.record(z.unknown());
+export type ConversationMetadata = z.infer<typeof ConversationMetadataSchema>;
+
+/** Conversation entity. */
+export const ConversationSchema = z.object({
+  id: z.string().uuid(),
+  gymId: z.string().uuid(),
+  branchId: z.string().uuid().nullable(),
+  type: ConversationTypeSchema,
+  metadata: ConversationMetadataSchema,
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+export type Conversation = z.infer<typeof ConversationSchema>;
+
+/** ConversationParticipant entity. */
+export const ConversationParticipantSchema = z.object({
+  conversationId: z.string().uuid(),
+  userId: z.string().uuid(),
+  role: z.string(),
+  joinedAt: z.string().datetime(),
+});
+export type ConversationParticipant = z.infer<typeof ConversationParticipantSchema>;
+
+/** MessageAttachment entity. */
+export const MessageAttachmentSchema = z.object({
+  id: z.string().uuid(),
+  messageId: z.string().uuid(),
+  storagePath: z.string(),
+  mimeType: z.string().nullable(),
+  filename: z.string().nullable(),
+  createdAt: z.string().datetime(),
+});
+export type MessageAttachment = z.infer<typeof MessageAttachmentSchema>;
+
+/** Message entity. */
+export const MessageSchema = z.object({
+  id: z.string().uuid(),
+  conversationId: z.string().uuid(),
+  senderId: z.string().uuid(),
+  content: z.string(),
+  dedupeKey: z.string().nullable(),
+  createdAt: z.string().datetime(),
+  attachments: z.array(MessageAttachmentSchema).optional(),
+});
+export type Message = z.infer<typeof MessageSchema>;
+
+/** MessageReceipt entity. */
+export const MessageReceiptSchema = z.object({
+  messageId: z.string().uuid(),
+  participantId: z.string().uuid(),
+  readAt: z.string().datetime(),
+});
+export type MessageReceipt = z.infer<typeof MessageReceiptSchema>;
+
+/** ConversationAssignment entity. */
+export const ConversationAssignmentSchema = z.object({
+  id: z.string().uuid(),
+  conversationId: z.string().uuid(),
+  assignedToUserId: z.string().uuid(),
+  assignedAt: z.string().datetime(),
+  assignedByUserId: z.string().uuid().nullable(),
+  unassignedAt: z.string().datetime().nullable(),
+});
+export type ConversationAssignment = z.infer<typeof ConversationAssignmentSchema>;
+
+/** TypingState — ephemeral; not persisted. */
+export const TypingStateSchema = z.object({
+  userId: z.string().uuid(),
+  conversationId: z.string().uuid(),
+  isTyping: z.boolean(),
+});
+export type TypingState = z.infer<typeof TypingStateSchema>;
+
+/** Input: Create conversation. */
+export const CreateConversationInputSchema = z.object({
+  gymId: z.string().uuid(),
+  branchId: z.string().uuid().nullable().optional(),
+  type: ConversationTypeSchema,
+  metadata: ConversationMetadataSchema.optional(),
+  participantUserIds: z.array(z.string().uuid()).min(1),
+});
+export type CreateConversationInput = z.infer<typeof CreateConversationInputSchema>;
+
+/** Input: Send message (idempotent via dedupe_key). */
+export const CreateMessageInputSchema = z.object({
+  content: z.string(),
+  dedupeKey: z.string().min(1),
+  attachmentPaths: z.array(z.string()).optional(),
+});
+export type CreateMessageInput = z.infer<typeof CreateMessageInputSchema>;
+
+/** Input: Mark message as read. */
+export const MessageReceiptUpdateSchema = z.object({
+  readAt: z.string().datetime().optional(),
+});
+export type MessageReceiptUpdate = z.infer<typeof MessageReceiptUpdateSchema>;
+
+/** Input: Assign conversation to staff. */
+export const AssignConversationInputSchema = z.object({
+  assignedToUserId: z.string().uuid(),
+});
+export type AssignConversationInput = z.infer<typeof AssignConversationInputSchema>;
+
+/** Query params for cursor-based pagination. */
+export const CursorPageParamsSchema = z.object({
+  cursor: z.string().optional(),
+  limit: z.number().int().min(1).max(100).default(20),
+});
+export type CursorPageParams = z.infer<typeof CursorPageParamsSchema>;
+
+/** Cursor-based page result schema factory. */
+export const createCursorPageResultSchema = <T extends z.ZodType>(itemSchema: T) =>
+  z.object({
+    items: z.array(itemSchema),
+    nextCursor: z.string().nullable(),
+  });
+
+export type CursorPageResult<T> = {
+  items: T[];
+  nextCursor: string | null;
+};
+
+/** Get conversation response (conversation + participants + assignment). */
+export const GetConversationResponseSchema = ConversationSchema.extend({
+  participants: z.array(ConversationParticipantSchema),
+  assignment: ConversationAssignmentSchema.nullable().optional(),
+});
+export type GetConversationResponse = z.infer<typeof GetConversationResponseSchema>;
+
+/** List conversations response (cursor-paginated). */
+export const ListConversationsResponseSchema = createCursorPageResultSchema(ConversationSchema);
+
+/** List messages response (cursor-paginated). */
+export const ListMessagesResponseSchema = createCursorPageResultSchema(MessageSchema);

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -5,5 +5,6 @@
  * API versioning: /api/v1.
  */
 export * from './auth';
+export * from './chat';
 export * from './health';
 export * from './locale';


### PR DESCRIPTION
Closes #98

Epic: #17

## Summary
Implement chat contract schemas and API contract definitions for the chat subsystem. Aligns with Task 17.1 (Chat database schema) and docs/07-technical-plan.md §7.3.

## Acceptance Criteria
- [x] All chat contract schemas in packages/contracts
- [x] Message creation includes dedupe_key for idempotency
- [x] Cursor-based pagination contract for message history
- [x] pnpm build and pnpm typecheck pass
- [x] Unit tests for schema validation

## Validation
- `pnpm build` — pass
- `pnpm typecheck` — pass  
- `pnpm test` — 82 tests in contracts (including 32 new chat tests)
- `pnpm lint` — pass

## Changed Files
- packages/contracts/src/chat/schemas.ts — entity and input schemas
- packages/contracts/src/chat/contracts.ts — API contract definitions
- packages/contracts/src/chat/chat.test.ts — unit tests
- packages/contracts/src/chat/index.ts — exports
- packages/contracts/package.json — ./chat subpath export
- packages/contracts/src/index.ts — chat re-export

Made with [Cursor](https://cursor.com)