### PR TITLE
feat(issue-99): Chat API routes and server logic

### DIFF
--- a/apps/web-gym-admin/app/api/v1/chat/conversations/[id]/assign/route.ts
+++ b/apps/web-gym-admin/app/api/v1/chat/conversations/[id]/assign/route.ts
@@ -1,0 +1,18 @@
+/**
+ * POST /api/v1/chat/conversations/:id/assign — Assign conversation to staff
+ *
+ * Task 17.3, Issue #99
+ */
+import type { NextRequest } from 'next/server';
+import { assignConversationContract } from '@myclup/contracts/chat';
+import { withAuthContractRoute } from '@/src/lib/withAuthContractRoute';
+import * as assignServer from '@/src/server/chat/assign';
+
+export async function POST(request: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+  const handler = withAuthContractRoute(assignConversationContract, async (req, input) => {
+    if (!input) return null;
+    return assignServer.assignConversation(req, id, input);
+  });
+  return handler(request);
+}

--- a/apps/web-gym-admin/app/api/v1/chat/conversations/[id]/messages/route.ts
+++ b/apps/web-gym-admin/app/api/v1/chat/conversations/[id]/messages/route.ts
@@ -1,0 +1,27 @@
+/**
+ * GET /api/v1/chat/conversations/:id/messages — List messages (cursor pagination)
+ * POST /api/v1/chat/conversations/:id/messages — Send message (idempotent via dedupe_key)
+ *
+ * Task 17.3, Issue #99
+ */
+import type { NextRequest } from 'next/server';
+import { listMessagesContract, sendMessageContract } from '@myclup/contracts/chat';
+import { withAuthContractRoute } from '@/src/lib/withAuthContractRoute';
+import * as msgServer from '@/src/server/chat/messages';
+
+export async function GET(request: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+  const handler = withAuthContractRoute(listMessagesContract, (req) =>
+    msgServer.listMessages(req, id)
+  );
+  return handler(request);
+}
+
+export async function POST(request: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+  const handler = withAuthContractRoute(sendMessageContract, async (req, input) => {
+    if (!input) return null;
+    return msgServer.sendMessage(req, id, input);
+  });
+  return handler(request);
+}

--- a/apps/web-gym-admin/app/api/v1/chat/conversations/[id]/route.ts
+++ b/apps/web-gym-admin/app/api/v1/chat/conversations/[id]/route.ts
@@ -1,0 +1,17 @@
+/**
+ * GET /api/v1/chat/conversations/:id — Get single conversation with participants and assignment
+ *
+ * Task 17.3, Issue #99
+ */
+import type { NextRequest } from 'next/server';
+import { getConversationContract } from '@myclup/contracts/chat';
+import { withAuthContractRoute } from '@/src/lib/withAuthContractRoute';
+import * as convServer from '@/src/server/chat/conversations';
+
+export async function GET(request: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+  const handler = withAuthContractRoute(getConversationContract, (req) =>
+    convServer.getConversation(req, id)
+  );
+  return handler(request);
+}

--- a/apps/web-gym-admin/app/api/v1/chat/conversations/route.test.ts
+++ b/apps/web-gym-admin/app/api/v1/chat/conversations/route.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Integration tests for GET/POST /api/v1/chat/conversations.
+ *
+ * Task 17.3, Issue #99
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { ListConversationsResponseSchema } from '@myclup/contracts/chat';
+
+vi.mock('@/src/server/chat/conversations', () => ({
+  listConversations: vi.fn(),
+  createConversation: vi.fn(),
+}));
+
+import { GET, POST } from './route';
+import * as convServer from '@/src/server/chat/conversations';
+
+const mockListConversations = vi.mocked(convServer.listConversations);
+const mockCreateConversation = vi.mocked(convServer.createConversation);
+
+describe('GET /api/v1/chat/conversations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockListConversations.mockResolvedValue(null);
+
+    const request = new NextRequest('http://localhost:3001/api/v1/chat/conversations');
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 200 with cursor-paginated items when authenticated', async () => {
+    mockListConversations.mockResolvedValue({
+      items: [
+        {
+          id: '550e8400-e29b-41d4-a716-446655440001',
+          gymId: '550e8400-e29b-41d4-a716-446655440000',
+          branchId: null,
+          type: 'direct',
+          metadata: {},
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-02T00:00:00.000Z',
+        },
+      ],
+      nextCursor: null,
+    });
+
+    const request = new NextRequest('http://localhost:3001/api/v1/chat/conversations', {
+      headers: { Authorization: 'Bearer test-token' },
+    });
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const json = (await response.json()) as unknown;
+    const parsed = ListConversationsResponseSchema.safeParse(json);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.items).toHaveLength(1);
+      expect(parsed.data.items[0].id).toBe('550e8400-e29b-41d4-a716-446655440001');
+      expect(parsed.data.nextCursor).toBeNull();
+    }
+  });
+});
+
+describe('POST /api/v1/chat/conversations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockCreateConversation.mockResolvedValue(null);
+
+    const request = new NextRequest('http://localhost:3001/api/v1/chat/conversations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        gymId: '550e8400-e29b-41d4-a716-446655440000',
+        type: 'direct',
+        participantUserIds: ['550e8400-e29b-41d4-a716-446655440001'],
+      }),
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 400 for invalid request body', async () => {
+    const request = new NextRequest('http://localhost:3001/api/v1/chat/conversations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        gymId: '550e8400-e29b-41d4-a716-446655440000',
+        type: 'invalid-type',
+        participantUserIds: [],
+      }),
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 200 with created conversation when authenticated and valid input', async () => {
+    mockCreateConversation.mockResolvedValue({
+      id: '550e8400-e29b-41d4-a716-446655440002',
+      gymId: '550e8400-e29b-41d4-a716-446655440000',
+      branchId: null,
+      type: 'direct',
+      metadata: {},
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    });
+
+    const input = {
+      gymId: '550e8400-e29b-41d4-a716-446655440000',
+      type: 'direct' as const,
+      participantUserIds: ['550e8400-e29b-41d4-a716-446655440001'],
+    };
+    const request = new NextRequest('http://localhost:3001/api/v1/chat/conversations', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer test-token',
+      },
+      body: JSON.stringify(input),
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const json = (await response.json()) as { id: string };
+    expect(json.id).toBe('550e8400-e29b-41d4-a716-446655440002');
+    expect(mockCreateConversation).toHaveBeenCalledWith(request, input);
+  });
+});

--- a/apps/web-gym-admin/app/api/v1/chat/conversations/route.ts
+++ b/apps/web-gym-admin/app/api/v1/chat/conversations/route.ts
@@ -1,0 +1,18 @@
+/**
+ * GET /api/v1/chat/conversations — List conversations (cursor pagination)
+ * POST /api/v1/chat/conversations — Create conversation
+ *
+ * Task 17.3, Issue #99
+ */
+import { listConversationsContract, createConversationContract } from '@myclup/contracts/chat';
+import { withAuthContractRoute } from '@/src/lib/withAuthContractRoute';
+import * as convServer from '@/src/server/chat/conversations';
+
+export const GET = withAuthContractRoute(listConversationsContract, async (req) =>
+  convServer.listConversations(req)
+);
+
+export const POST = withAuthContractRoute(createConversationContract, async (req, input) => {
+  if (!input) return null;
+  return convServer.createConversation(req, input);
+});

--- a/apps/web-gym-admin/app/api/v1/chat/messages/[id]/receipts/route.ts
+++ b/apps/web-gym-admin/app/api/v1/chat/messages/[id]/receipts/route.ts
@@ -1,0 +1,17 @@
+/**
+ * PATCH /api/v1/chat/messages/:id/receipts — Mark message as read
+ *
+ * Task 17.3, Issue #99
+ */
+import type { NextRequest } from 'next/server';
+import { markReadContract } from '@myclup/contracts/chat';
+import { withAuthContractRoute } from '@/src/lib/withAuthContractRoute';
+import * as receiptsServer from '@/src/server/chat/receipts';
+
+export async function PATCH(request: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+  const handler = withAuthContractRoute(markReadContract, (req) =>
+    receiptsServer.markRead(req, id)
+  );
+  return handler(request);
+}

--- a/apps/web-gym-admin/src/lib/withAuthContractRoute.ts
+++ b/apps/web-gym-admin/src/lib/withAuthContractRoute.ts
@@ -12,7 +12,7 @@
 
 import type { NextRequest } from 'next/server';
 import { z } from 'zod';
-import { ForbiddenError } from '@myclup/supabase';
+import { ForbiddenError, NotFoundError } from '@myclup/supabase';
 
 /** Contract shape: path, method, optional request schema, response schema. */
 type ApiContract = {
@@ -77,6 +77,9 @@ export function withAuthContractRoute<TRequest, TResponse>(
     } catch (err) {
       if (err instanceof ForbiddenError) {
         return errorResponse(403, 'forbidden');
+      }
+      if (err instanceof NotFoundError) {
+        return errorResponse(404, 'not_found');
       }
       if (err instanceof SyntaxError) {
         return errorResponse(400, 'validation_error', 'Invalid JSON body');

--- a/apps/web-gym-admin/src/server/chat/assign.ts
+++ b/apps/web-gym-admin/src/server/chat/assign.ts
@@ -1,0 +1,101 @@
+/**
+ * Chat conversation assignment server module.
+ *
+ * Assign conversation to staff. Unassigns current assignment, inserts new one.
+ * Audit: assignment changes preserve auditability.
+ *
+ * ⚠️ SERVER-ONLY: Never import in client components or pages.
+ */
+
+import type { NextRequest } from 'next/server';
+import type { AssignConversationInput, ConversationAssignment } from '@myclup/contracts/chat';
+import {
+  getCurrentUser,
+  createServerClient,
+  requirePermission,
+  NotFoundError,
+} from '@myclup/supabase';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL || '';
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+
+function dbToAssignment(row: {
+  id: string;
+  conversation_id: string;
+  assigned_to_user_id: string;
+  assigned_at: string;
+  assigned_by_user_id: string | null;
+  unassigned_at: string | null;
+}): ConversationAssignment {
+  return {
+    id: row.id,
+    conversationId: row.conversation_id,
+    assignedToUserId: row.assigned_to_user_id,
+    assignedAt: row.assigned_at,
+    assignedByUserId: row.assigned_by_user_id,
+    unassignedAt: row.unassigned_at,
+  };
+}
+
+/**
+ * Assign conversation to a staff user.
+ * Requires chat:write permission in the conversation's gym.
+ */
+export async function assignConversation(
+  req: NextRequest,
+  conversationId: string,
+  input: AssignConversationInput
+): Promise<ConversationAssignment | null> {
+  const currentUser = await getCurrentUser(req);
+  if (!currentUser) return null;
+  if (!SUPABASE_URL || !SERVICE_ROLE_KEY) return null;
+
+  const client = createServerClient({
+    supabaseUrl: SUPABASE_URL,
+    serviceRoleKey: SERVICE_ROLE_KEY,
+  });
+
+  const userId = currentUser.user.id;
+
+  const { data: conv } = await client
+    .from('conversations')
+    .select('id, gym_id, branch_id')
+    .eq('id', conversationId)
+    .single();
+
+  if (!conv) {
+    throw new NotFoundError('Conversation not found');
+  }
+
+  const scope = { gymId: conv.gym_id, branchId: conv.branch_id };
+  await requirePermission(client, userId, scope, 'chat:write');
+
+  const now = new Date().toISOString();
+
+  // Unassign current active assignment(s)
+  await client
+    .from('conversation_assignments')
+    .update({ unassigned_at: now })
+    .eq('conversation_id', conversationId)
+    .is('unassigned_at', null);
+
+  const { data: inserted, error } = await client
+    .from('conversation_assignments')
+    .insert({
+      conversation_id: conversationId,
+      assigned_to_user_id: input.assignedToUserId,
+      assigned_at: now,
+      assigned_by_user_id: userId,
+    })
+    .select(
+      'id, conversation_id, assigned_to_user_id, assigned_at, assigned_by_user_id, unassigned_at'
+    )
+    .single();
+
+  if (error || !inserted) {
+    console.error('[chat/assign] error:', error);
+    throw new Error('Failed to assign conversation');
+  }
+
+  return dbToAssignment(inserted as Parameters<typeof dbToAssignment>[0]);
+}

--- a/apps/web-gym-admin/src/server/chat/conversations.ts
+++ b/apps/web-gym-admin/src/server/chat/conversations.ts
@@ -1,0 +1,268 @@
+/**
+ * Chat conversations server module.
+ *
+ * List, get, create conversations. Enforces tenant isolation via gym_id derived
+ * from authenticated user's role assignments. Never trust client-provided tenant.
+ *
+ * ⚠️ SERVER-ONLY: Never import in client components or pages.
+ */
+
+import type { NextRequest } from 'next/server';
+import type {
+  Conversation,
+  CreateConversationInput,
+  CursorPageParams,
+  CursorPageResult,
+  GetConversationResponse,
+} from '@myclup/contracts/chat';
+import { CursorPageParamsSchema } from '@myclup/contracts/chat';
+import type { Json } from '@myclup/supabase';
+import {
+  getCurrentUser,
+  createServerClient,
+  resolveTenantScope,
+  requirePermission,
+  ForbiddenError,
+  NotFoundError,
+} from '@myclup/supabase';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL || '';
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+
+function getClient() {
+  return createServerClient({
+    supabaseUrl: SUPABASE_URL,
+    serviceRoleKey: SERVICE_ROLE_KEY,
+  });
+}
+
+/** Parse and validate cursor pagination from URL search params. */
+function parseCursorParams(req: NextRequest): CursorPageParams {
+  const sp = req.nextUrl.searchParams;
+  const limitParam = sp.get('limit');
+  const limit = limitParam ? parseInt(limitParam, 10) : 20;
+  const cursor = sp.get('cursor') ?? undefined;
+  const parsed = CursorPageParamsSchema.safeParse({ cursor, limit });
+  if (!parsed.success) {
+    return { cursor: undefined, limit: 20 };
+  }
+  return parsed.data;
+}
+
+/** Map DB row to contract Conversation. */
+function toConversation(row: {
+  id: string;
+  gym_id: string;
+  branch_id: string | null;
+  type: string;
+  metadata: unknown;
+  created_at: string;
+  updated_at: string;
+}): Conversation {
+  return {
+    id: row.id,
+    gymId: row.gym_id,
+    branchId: row.branch_id,
+    type: row.type as Conversation['type'],
+    metadata: (row.metadata as Record<string, unknown>) ?? {},
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+/**
+ * List conversations for the authenticated user.
+ * Returns only conversations where the user is a participant.
+ * Tenant isolation: RLS + server enforces user is participant.
+ */
+export async function listConversations(
+  req: NextRequest
+): Promise<CursorPageResult<Conversation> | null> {
+  const currentUser = await getCurrentUser(req);
+  if (!currentUser) return null;
+  if (!SUPABASE_URL || !SERVICE_ROLE_KEY) return null;
+
+  const params = parseCursorParams(req);
+  const client = getClient();
+  const userId = currentUser.user.id;
+
+  // Get conversation IDs where user is participant
+  const { data: participantRows, error: partErr } = await client
+    .from('conversation_participants')
+    .select('conversation_id')
+    .eq('user_id', userId);
+
+  if (partErr || !participantRows?.length) {
+    return { items: [], nextCursor: null };
+  }
+
+  const conversationIds = participantRows.map((r) => r.conversation_id);
+
+  let query = client
+    .from('conversations')
+    .select('id, gym_id, branch_id, type, metadata, created_at, updated_at')
+    .in('id', conversationIds)
+    .order('updated_at', { ascending: false })
+    .limit(params.limit + 1);
+
+  if (params.cursor) {
+    const { data: cursorRow } = await client
+      .from('conversations')
+      .select('updated_at')
+      .eq('id', params.cursor)
+      .single();
+    if (cursorRow?.updated_at) {
+      query = query.lt('updated_at', cursorRow.updated_at);
+    }
+  }
+
+  const { data: rows, error } = await query;
+
+  if (error || !rows) {
+    return { items: [], nextCursor: null };
+  }
+
+  const hasMore = rows.length > params.limit;
+  const items = (hasMore ? rows.slice(0, params.limit) : rows).map(toConversation);
+  const nextCursor = hasMore ? (rows[params.limit - 1]?.id ?? null) : null;
+
+  return { items, nextCursor };
+}
+
+/**
+ * Get a single conversation with participants and assignment.
+ * Validates membership: user must be participant or have gym staff access.
+ */
+export async function getConversation(
+  req: NextRequest,
+  conversationId: string
+): Promise<GetConversationResponse | null> {
+  const currentUser = await getCurrentUser(req);
+  if (!currentUser) return null;
+  if (!SUPABASE_URL || !SERVICE_ROLE_KEY) return null;
+
+  const client = getClient();
+  const userId = currentUser.user.id;
+
+  const { data: conv, error: convErr } = await client
+    .from('conversations')
+    .select('id, gym_id, branch_id, type, metadata, created_at, updated_at')
+    .eq('id', conversationId)
+    .single();
+
+  if (convErr || !conv) throw new NotFoundError('Conversation not found');
+
+  // Validate access: user must be participant or have gym access
+  const { data: participant } = await client
+    .from('conversation_participants')
+    .select('user_id')
+    .eq('conversation_id', conversationId)
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  const isParticipant = !!participant;
+
+  if (!isParticipant) {
+    const scopes = await resolveTenantScope(client, userId, conv.gym_id);
+    if (scopes.length === 0) {
+      throw new ForbiddenError('User is not a participant and has no gym access');
+    }
+    await requirePermission(
+      client,
+      userId,
+      { gymId: conv.gym_id, branchId: conv.branch_id },
+      'chat:read'
+    );
+  }
+
+  const { data: participantRows } = await client
+    .from('conversation_participants')
+    .select('conversation_id, user_id, role, joined_at')
+    .eq('conversation_id', conversationId);
+
+  const { data: assignmentRow } = await client
+    .from('conversation_assignments')
+    .select(
+      'id, conversation_id, assigned_to_user_id, assigned_at, assigned_by_user_id, unassigned_at'
+    )
+    .eq('conversation_id', conversationId)
+    .is('unassigned_at', null)
+    .order('assigned_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  return {
+    ...toConversation(conv),
+    participants: (participantRows ?? []).map((p) => ({
+      conversationId: p.conversation_id,
+      userId: p.user_id,
+      role: p.role,
+      joinedAt: p.joined_at,
+    })),
+    assignment: assignmentRow
+      ? {
+          id: assignmentRow.id,
+          conversationId: assignmentRow.conversation_id,
+          assignedToUserId: assignmentRow.assigned_to_user_id,
+          assignedAt: assignmentRow.assigned_at,
+          assignedByUserId: assignmentRow.assigned_by_user_id,
+          unassignedAt: assignmentRow.unassigned_at,
+        }
+      : null,
+  };
+}
+
+/**
+ * Create a new conversation.
+ * Validates that gymId is in the user's permitted scopes. Never trust client-provided tenant.
+ */
+export async function createConversation(
+  req: NextRequest,
+  input: CreateConversationInput
+): Promise<Conversation | null> {
+  const currentUser = await getCurrentUser(req);
+  if (!currentUser) return null;
+  if (!SUPABASE_URL || !SERVICE_ROLE_KEY) return null;
+
+  const client = getClient();
+  const userId = currentUser.user.id;
+
+  // Validate tenant scope: user must have access to the gym
+  const scopes = await resolveTenantScope(client, userId, input.gymId);
+  if (scopes.length === 0) {
+    throw new ForbiddenError('User does not have access to the specified gym');
+  }
+  await requirePermission(
+    client,
+    userId,
+    { gymId: input.gymId, branchId: input.branchId ?? null },
+    'chat:write'
+  );
+
+  const { data: conv, error } = await client
+    .from('conversations')
+    .insert({
+      gym_id: input.gymId,
+      branch_id: input.branchId ?? null,
+      type: input.type,
+      metadata: (input.metadata ?? {}) as Json,
+    })
+    .select('id, gym_id, branch_id, type, metadata, created_at, updated_at')
+    .single();
+
+  if (error || !conv) return null;
+
+  const participants = input.participantUserIds.map((uid, i) => ({
+    conversation_id: conv.id,
+    user_id: uid,
+    role: i === 0 ? 'creator' : 'member',
+  }));
+
+  const { error: partErr } = await client.from('conversation_participants').insert(participants);
+  if (partErr) {
+    console.error('[chat] failed to insert participants:', partErr);
+    return null;
+  }
+
+  return toConversation(conv);
+}

--- a/apps/web-gym-admin/src/server/chat/messages.ts
+++ b/apps/web-gym-admin/src/server/chat/messages.ts
@@ -1,0 +1,283 @@
+/**
+ * Chat messages server module.
+ *
+ * List messages (cursor pagination), send message (idempotent via dedupe_key).
+ * Validates membership before message access.
+ *
+ * ⚠️ SERVER-ONLY: Never import in client components or pages.
+ */
+
+import type { NextRequest } from 'next/server';
+import type {
+  CreateMessageInput,
+  CursorPageParams,
+  CursorPageResult,
+  Message,
+} from '@myclup/contracts/chat';
+import { CursorPageParamsSchema } from '@myclup/contracts/chat';
+import {
+  getCurrentUser,
+  createServerClient,
+  resolveTenantScope,
+  ForbiddenError,
+  NotFoundError,
+} from '@myclup/supabase';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL || '';
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+
+function dbToMessage(row: {
+  id: string;
+  conversation_id: string;
+  sender_id: string;
+  content: string;
+  dedupe_key: string | null;
+  created_at: string;
+  message_attachments?: Array<{
+    id: string;
+    message_id: string;
+    storage_path: string;
+    mime_type: string | null;
+    filename: string | null;
+    created_at: string;
+  }>;
+}): Message {
+  return {
+    id: row.id,
+    conversationId: row.conversation_id,
+    senderId: row.sender_id,
+    content: row.content,
+    dedupeKey: row.dedupe_key,
+    createdAt: row.created_at,
+    attachments: row.message_attachments?.map((a) => ({
+      id: a.id,
+      messageId: a.message_id,
+      storagePath: a.storage_path,
+      mimeType: a.mime_type,
+      filename: a.filename,
+      createdAt: a.created_at,
+    })),
+  };
+}
+
+/**
+ * Parse cursor pagination params from URL search params.
+ */
+function parseCursorParams(req: NextRequest): CursorPageParams {
+  const params = req.nextUrl.searchParams;
+  const limitParam = params.get('limit');
+  const limit = limitParam ? parseInt(limitParam, 10) : 20;
+  const cursor = params.get('cursor') ?? undefined;
+  const parsed = CursorPageParamsSchema.safeParse({ cursor, limit });
+  if (!parsed.success) {
+    return { cursor: undefined, limit: 20 };
+  }
+  return parsed.data;
+}
+
+/**
+ * List messages for a conversation. Cursor-based pagination.
+ * Validates membership before access.
+ */
+export async function listMessages(
+  req: NextRequest,
+  conversationId: string
+): Promise<CursorPageResult<Message> | null> {
+  const currentUser = await getCurrentUser(req);
+  if (!currentUser) return null;
+  if (!SUPABASE_URL || !SERVICE_ROLE_KEY) return null;
+
+  const client = createServerClient({
+    supabaseUrl: SUPABASE_URL,
+    serviceRoleKey: SERVICE_ROLE_KEY,
+  });
+
+  const userId = currentUser.user.id;
+
+  // Validate membership: user must be a participant
+  const { data: participant } = await client
+    .from('conversation_participants')
+    .select('conversation_id')
+    .eq('conversation_id', conversationId)
+    .eq('user_id', userId)
+    .single();
+
+  if (!participant) {
+    throw new ForbiddenError('Not a participant in this conversation');
+  }
+
+  // Fetch conversation to verify tenant scope
+  const { data: conv } = await client
+    .from('conversations')
+    .select('gym_id')
+    .eq('id', conversationId)
+    .single();
+
+  if (!conv) {
+    throw new NotFoundError('Conversation not found');
+  }
+
+  const scopes = await resolveTenantScope(client, userId, conv.gym_id);
+  if (scopes.length === 0) {
+    throw new ForbiddenError('No access to this gym');
+  }
+
+  const params = parseCursorParams(req);
+  const pageSize = params.limit + 1;
+
+  let query = client
+    .from('messages')
+    .select('id, conversation_id, sender_id, content, dedupe_key, created_at')
+    .eq('conversation_id', conversationId)
+    .order('created_at', { ascending: false })
+    .limit(pageSize);
+
+  if (params.cursor) {
+    // Cursor is created_at of the last message; fetch messages before that
+    const { data: cursorMsg } = await client
+      .from('messages')
+      .select('created_at')
+      .eq('id', params.cursor)
+      .eq('conversation_id', conversationId)
+      .single();
+
+    if (cursorMsg) {
+      query = query.lt('created_at', cursorMsg.created_at);
+    }
+  }
+
+  const { data: rows, error } = await query;
+
+  if (error) {
+    console.error('[chat/messages] list error:', error);
+    throw new Error('Failed to list messages');
+  }
+
+  const items = (rows ?? [])
+    .slice(0, params.limit)
+    .map((r: unknown) => dbToMessage(r as Parameters<typeof dbToMessage>[0]));
+  const hasMore = (rows ?? []).length > params.limit;
+  const nextCursor = hasMore && items.length > 0 ? items[items.length - 1].id : null;
+
+  return { items, nextCursor };
+}
+
+/**
+ * Send a message. Idempotent via dedupe_key.
+ * If a message with the same (conversation_id, dedupe_key) exists, return it.
+ */
+export async function sendMessage(
+  req: NextRequest,
+  conversationId: string,
+  input: CreateMessageInput
+): Promise<Message | null> {
+  const currentUser = await getCurrentUser(req);
+  if (!currentUser) return null;
+  if (!SUPABASE_URL || !SERVICE_ROLE_KEY) return null;
+
+  const client = createServerClient({
+    supabaseUrl: SUPABASE_URL,
+    serviceRoleKey: SERVICE_ROLE_KEY,
+  });
+
+  const userId = currentUser.user.id;
+
+  // Validate membership
+  const { data: participant } = await client
+    .from('conversation_participants')
+    .select('conversation_id')
+    .eq('conversation_id', conversationId)
+    .eq('user_id', userId)
+    .single();
+
+  if (!participant) {
+    throw new ForbiddenError('Not a participant in this conversation');
+  }
+
+  const { data: conv } = await client
+    .from('conversations')
+    .select('gym_id')
+    .eq('id', conversationId)
+    .single();
+
+  if (!conv) {
+    throw new NotFoundError('Conversation not found');
+  }
+
+  const scopes = await resolveTenantScope(client, userId, conv.gym_id);
+  if (scopes.length === 0) {
+    throw new ForbiddenError('No access to this gym');
+  }
+
+  // Idempotency: check for existing message with same dedupe_key
+  const { data: existing } = await client
+    .from('messages')
+    .select(
+      `
+      id,
+      conversation_id,
+      sender_id,
+      content,
+      dedupe_key,
+      created_at
+    `
+    )
+    .eq('conversation_id', conversationId)
+    .eq('dedupe_key', input.dedupeKey)
+    .single();
+
+  if (existing) {
+    return dbToMessage({
+      ...existing,
+      message_attachments: [],
+    });
+  }
+
+  const { data: inserted, error } = await client
+    .from('messages')
+    .insert({
+      conversation_id: conversationId,
+      sender_id: userId,
+      content: input.content,
+      dedupe_key: input.dedupeKey,
+    })
+    .select(
+      `
+      id,
+      conversation_id,
+      sender_id,
+      content,
+      dedupe_key,
+      created_at
+    `
+    )
+    .single();
+
+  if (error) {
+    // Handle unique constraint violation (race condition)
+    if (error.code === '23505') {
+      const { data: raceExisting } = await client
+        .from('messages')
+        .select(
+          `
+          id,
+          conversation_id,
+          sender_id,
+          content,
+          dedupe_key,
+          created_at
+        `
+        )
+        .eq('conversation_id', conversationId)
+        .eq('dedupe_key', input.dedupeKey)
+        .single();
+      if (raceExisting) {
+        return dbToMessage({ ...raceExisting, message_attachments: [] });
+      }
+    }
+    console.error('[chat/messages] send error:', error);
+    throw new Error('Failed to send message');
+  }
+
+  return dbToMessage({ ...inserted, message_attachments: [] });
+}

--- a/apps/web-gym-admin/src/server/chat/receipts.ts
+++ b/apps/web-gym-admin/src/server/chat/receipts.ts
@@ -1,0 +1,99 @@
+/**
+ * Chat message receipts server module.
+ *
+ * Mark message as read (upsert receipt).
+ * Validates membership before access.
+ *
+ * ⚠️ SERVER-ONLY: Never import in client components or pages.
+ */
+
+import type { NextRequest } from 'next/server';
+import type { MessageReceiptUpdate } from '@myclup/contracts/chat';
+import {
+  getCurrentUser,
+  createServerClient,
+  resolveTenantScope,
+  ForbiddenError,
+  NotFoundError,
+} from '@myclup/supabase';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL || '';
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+
+/**
+ * Mark a message as read for the current user.
+ * Uses message_id from path; participant_id = current user.
+ */
+export async function markRead(
+  req: NextRequest,
+  messageId: string
+): Promise<MessageReceiptUpdate | null> {
+  const currentUser = await getCurrentUser(req);
+  if (!currentUser) return null;
+  if (!SUPABASE_URL || !SERVICE_ROLE_KEY) return null;
+
+  const client = createServerClient({
+    supabaseUrl: SUPABASE_URL,
+    serviceRoleKey: SERVICE_ROLE_KEY,
+  });
+
+  const userId = currentUser.user.id;
+
+  // Fetch message and conversation
+  const { data: msg } = await client
+    .from('messages')
+    .select('id, conversation_id')
+    .eq('id', messageId)
+    .single();
+
+  if (!msg) {
+    throw new NotFoundError('Message not found');
+  }
+
+  // Validate membership
+  const { data: participant } = await client
+    .from('conversation_participants')
+    .select('conversation_id')
+    .eq('conversation_id', msg.conversation_id)
+    .eq('user_id', userId)
+    .single();
+
+  if (!participant) {
+    throw new ForbiddenError('Not a participant in this conversation');
+  }
+
+  const { data: conv } = await client
+    .from('conversations')
+    .select('gym_id')
+    .eq('id', msg.conversation_id)
+    .single();
+
+  if (!conv) {
+    throw new NotFoundError('Conversation not found');
+  }
+
+  const scopes = await resolveTenantScope(client, userId, conv.gym_id);
+  if (scopes.length === 0) {
+    throw new ForbiddenError('No access to this gym');
+  }
+
+  const readAt = new Date().toISOString();
+
+  const { error } = await client.from('message_receipts').upsert(
+    {
+      message_id: messageId,
+      participant_id: userId,
+      read_at: readAt,
+    },
+    {
+      onConflict: 'message_id,participant_id',
+    }
+  );
+
+  if (error) {
+    console.error('[chat/receipts] markRead error:', error);
+    throw new Error('Failed to mark message as read');
+  }
+
+  return { readAt };
+}

--- a/packages/supabase/src/auth/index.ts
+++ b/packages/supabase/src/auth/index.ts
@@ -33,6 +33,7 @@ export {
   checkPermission,
   requirePermission,
   ForbiddenError,
+  NotFoundError,
   ROLE_PERMISSIONS,
   type AnyRole,
 } from './permissions';

--- a/packages/supabase/src/auth/permissions.ts
+++ b/packages/supabase/src/auth/permissions.ts
@@ -38,6 +38,19 @@ export class ForbiddenError extends Error {
 }
 
 /**
+ * Thrown when a requested resource does not exist.
+ * Callers should map this to a 404 response.
+ */
+export class NotFoundError extends Error {
+  readonly statusCode = 404;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'NotFoundError';
+  }
+}
+
+/**
  * Role → FeaturePermission mapping.
  *
  * Platform admins have full access to everything.

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -27,6 +27,7 @@ export {
   checkPermission,
   requirePermission,
   ForbiddenError,
+  NotFoundError,
   ROLE_PERMISSIONS,
   type AuthRequest,
   type CurrentUser,


### PR DESCRIPTION
Closes #99

**Epic**: #17 — Chat, Notifications, and Communication Platform

## Summary

Implements Next.js BFF API routes for chat CRUD operations. Enforces tenant isolation, membership validation, and server-side permission checks. Supports cursor-based message pagination and idempotent message creation.

## Routes Implemented

- **GET** /api/v1/chat/conversations — List conversations (cursor pagination)
- **POST** /api/v1/chat/conversations — Create conversation
- **GET** /api/v1/chat/conversations/:id — Get conversation with participants and assignment
- **GET** /api/v1/chat/conversations/:id/messages — List messages (cursor pagination)
- **POST** /api/v1/chat/conversations/:id/messages — Send message (idempotent via dedupe_key)
- **PATCH** /api/v1/chat/messages/:id/receipts — Mark message as read
- **POST** /api/v1/chat/conversations/:id/assign — Assign conversation to staff

## Acceptance Criteria

- [x] All chat routes implemented with contract validation
- [x] Tenant isolation enforced on every query
- [x] Membership validated before message access
- [x] Message creation is idempotent (dedupe_key)
- [x] Cursor-based pagination for message history
- [x] Permission checks server-side only
- [x] Integration tests for conversations route

## Files Changed

- `apps/web-gym-admin/app/api/v1/chat/*` — Route handlers
- `apps/web-gym-admin/src/server/chat/*` — Server modules
- `packages/supabase` — Added NotFoundError for 404 handling
- `apps/web-gym-admin/src/lib/withAuthContractRoute.ts` — NotFoundError support

Made with [Cursor](https://cursor.com)