### PR TITLE
feat(issue-100): api-client Chat Methods

### DIFF
--- a/packages/api-client/src/chat.test.ts
+++ b/packages/api-client/src/chat.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Unit tests for the chat API namespace.
+ *
+ * Verifies path param substitution, query params for GET, and response parsing.
+ * Uses mocked fetch to avoid live network calls.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createApi, ApiError } from './index';
+
+const CONV_ID = '11111111-1111-1111-1111-111111111111';
+const MSG_ID = '22222222-2222-2222-2222-222222222222';
+const GYM_ID = '33333333-3333-3333-3333-333333333333';
+const USER_ID = '44444444-4444-4444-4444-444444444444';
+const USER_ID_2 = '55555555-5555-5555-5555-555555555555';
+const ASSIGN_ID = '66666666-6666-6666-6666-666666666666';
+
+const MOCK_CONVERSATION = {
+  id: CONV_ID,
+  gymId: GYM_ID,
+  branchId: null,
+  type: 'direct' as const,
+  metadata: {},
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+  participants: [
+    { conversationId: CONV_ID, userId: USER_ID, role: 'member', joinedAt: '2024-01-01T00:00:00Z' },
+  ],
+  assignment: null,
+};
+
+const MOCK_MESSAGE = {
+  id: MSG_ID,
+  conversationId: CONV_ID,
+  senderId: USER_ID,
+  content: 'Hello',
+  dedupeKey: 'msg-1',
+  createdAt: '2024-01-01T00:00:00Z',
+};
+
+const MOCK_LIST_CONVERSATIONS = { items: [MOCK_CONVERSATION], nextCursor: null };
+const MOCK_LIST_MESSAGES = { items: [MOCK_MESSAGE], nextCursor: null };
+
+function mockFetch(status: number, body: unknown): typeof fetch {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : String(status),
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  }) as unknown as typeof fetch;
+}
+
+describe('chat.conversations', () => {
+  it('get substitutes :id in path and returns parsed response', async () => {
+    const mockFetchFn = mockFetch(200, MOCK_CONVERSATION);
+    const api = createApi({ baseUrl: 'http://localhost:3001', fetch: mockFetchFn });
+
+    const result = await api.chat.conversations.get(CONV_ID);
+
+    expect(mockFetchFn).toHaveBeenCalledWith(
+      'http://localhost:3001/api/v1/chat/conversations/11111111-1111-1111-1111-111111111111',
+      expect.any(Object)
+    );
+    expect(result.id).toBe(CONV_ID);
+    expect(result.participants).toHaveLength(1);
+  });
+
+  it('list sends query params for GET', async () => {
+    const mockFetchFn = mockFetch(200, MOCK_LIST_CONVERSATIONS);
+    const api = createApi({ baseUrl: 'http://localhost:3001', fetch: mockFetchFn });
+
+    await api.chat.conversations.list({ cursor: 'abc', limit: 10 });
+
+    expect(mockFetchFn).toHaveBeenCalledWith(
+      'http://localhost:3001/api/v1/chat/conversations?cursor=abc&limit=10',
+      expect.any(Object)
+    );
+  });
+
+  it('create POSTs with body', async () => {
+    const mockFetchFn = mockFetch(200, MOCK_CONVERSATION);
+    const api = createApi({ baseUrl: 'http://localhost:3001', fetch: mockFetchFn });
+    const input = {
+      gymId: GYM_ID,
+      type: 'direct' as const,
+      participantUserIds: [USER_ID_2],
+    };
+
+    const result = await api.chat.conversations.create(input);
+
+    expect(mockFetchFn).toHaveBeenCalledWith(
+      'http://localhost:3001/api/v1/chat/conversations',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify(input) })
+    );
+    expect(result.id).toBe(CONV_ID);
+  });
+
+  it('assign substitutes :id and POSTs input', async () => {
+    const mockAssign = {
+      id: ASSIGN_ID,
+      conversationId: CONV_ID,
+      assignedToUserId: USER_ID_2,
+      assignedAt: '2024-01-01T00:00:00Z',
+      assignedByUserId: null,
+      unassignedAt: null,
+    };
+    const mockFetchFn = mockFetch(200, mockAssign);
+    const api = createApi({ baseUrl: 'http://localhost:3001', fetch: mockFetchFn });
+
+    const result = await api.chat.conversations.assign(CONV_ID, { assignedToUserId: USER_ID_2 });
+
+    expect(mockFetchFn).toHaveBeenCalledWith(
+      'http://localhost:3001/api/v1/chat/conversations/11111111-1111-1111-1111-111111111111/assign',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ assignedToUserId: USER_ID_2 }),
+      })
+    );
+    expect(result.assignedToUserId).toBe(USER_ID_2);
+  });
+});
+
+describe('chat.messages', () => {
+  it('list substitutes conversation :id and sends query params', async () => {
+    const mockFetchFn = mockFetch(200, MOCK_LIST_MESSAGES);
+    const api = createApi({ baseUrl: 'http://localhost:3001', fetch: mockFetchFn });
+
+    await api.chat.messages.list(CONV_ID, { limit: 5 });
+
+    expect(mockFetchFn).toHaveBeenCalledWith(
+      'http://localhost:3001/api/v1/chat/conversations/11111111-1111-1111-1111-111111111111/messages?limit=5',
+      expect.any(Object)
+    );
+  });
+
+  it('send POSTs payload with conversation :id', async () => {
+    const mockFetchFn = mockFetch(200, MOCK_MESSAGE);
+    const api = createApi({ baseUrl: 'http://localhost:3001', fetch: mockFetchFn });
+    const payload = { content: 'Hello', dedupeKey: 'msg-1' };
+
+    const result = await api.chat.messages.send(CONV_ID, payload);
+
+    expect(mockFetchFn).toHaveBeenCalledWith(
+      'http://localhost:3001/api/v1/chat/conversations/11111111-1111-1111-1111-111111111111/messages',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify(payload) })
+    );
+    expect(result.content).toBe('Hello');
+  });
+
+  it('markRead substitutes message :id and PATCHes', async () => {
+    const mockReceipt = { readAt: '2024-01-01T00:00:00Z' };
+    const mockFetchFn = mockFetch(200, mockReceipt);
+    const api = createApi({ baseUrl: 'http://localhost:3001', fetch: mockFetchFn });
+
+    const result = await api.chat.messages.markRead(MSG_ID);
+
+    expect(mockFetchFn).toHaveBeenCalledWith(
+      'http://localhost:3001/api/v1/chat/messages/22222222-2222-2222-2222-222222222222/receipts',
+      expect.objectContaining({ method: 'PATCH', body: '{}' })
+    );
+    expect(result).toBeDefined();
+  });
+
+  it('throws ApiError on non-2xx', async () => {
+    const api = createApi({
+      baseUrl: 'http://localhost:3001',
+      fetch: mockFetch(404, { error: 'not found' }),
+    });
+
+    await expect(api.chat.conversations.get(CONV_ID)).rejects.toBeInstanceOf(ApiError);
+    await expect(api.chat.conversations.get(CONV_ID)).rejects.toMatchObject({ status: 404 });
+  });
+});

--- a/packages/api-client/src/chat.ts
+++ b/packages/api-client/src/chat.ts
@@ -1,0 +1,143 @@
+/**
+ * Chat API namespace for the shared api-client.
+ *
+ * Provides typed methods for conversations (list, get, create, assign)
+ * and messages (list, send, markRead). Uses path param substitution
+ * for routes like /api/v1/chat/conversations/:id.
+ *
+ * Realtime subscription is handled in apps; broadcast/template methods
+ * are out of scope (Task 17.6).
+ */
+
+import type {
+  AssignConversationInput,
+  Conversation,
+  ConversationAssignment,
+  CreateConversationInput,
+  CreateMessageInput,
+  CursorPageParams,
+  GetConversationResponse,
+  Message,
+  MessageReceiptUpdate,
+} from '@myclup/contracts/chat';
+import {
+  assignConversationContract,
+  createConversationContract,
+  getConversationContract,
+  listConversationsContract,
+  listMessagesContract,
+  markReadContract,
+  sendMessageContract,
+} from '@myclup/contracts/chat';
+import type { ApiContract } from './client';
+import type { RequestOptions } from './client';
+
+type RequestFn = <T>(
+  contract: ApiContract<unknown, T>,
+  requestData?: unknown,
+  options?: RequestOptions
+) => Promise<T>;
+
+/** Cursor-paginated list response. */
+type ListConversationsResponse = { items: Conversation[]; nextCursor: string | null };
+type ListMessagesResponse = { items: Message[]; nextCursor: string | null };
+
+/**
+ * Creates the chat API namespace with typed methods.
+ * All responses are validated against their contract schemas.
+ */
+export function createChatApi(request: RequestFn) {
+  return {
+    conversations: {
+      /**
+       * GET /api/v1/chat/conversations
+       * List conversations with optional cursor pagination.
+       */
+      async list(params?: CursorPageParams): Promise<ListConversationsResponse> {
+        return request(
+          listConversationsContract as ApiContract<CursorPageParams, ListConversationsResponse>,
+          params
+        );
+      },
+
+      /**
+       * GET /api/v1/chat/conversations/:id
+       * Get a conversation by ID with participants and assignment.
+       */
+      async get(id: string): Promise<GetConversationResponse> {
+        return request(
+          getConversationContract as ApiContract<unknown, GetConversationResponse>,
+          undefined,
+          { pathParams: { id } }
+        );
+      },
+
+      /**
+       * POST /api/v1/chat/conversations
+       * Create a new conversation.
+       */
+      async create(input: CreateConversationInput): Promise<Conversation> {
+        return request(
+          createConversationContract as ApiContract<CreateConversationInput, Conversation>,
+          input
+        );
+      },
+
+      /**
+       * POST /api/v1/chat/conversations/:id/assign
+       * Assign a conversation to staff.
+       */
+      async assign(
+        conversationId: string,
+        input: AssignConversationInput
+      ): Promise<ConversationAssignment> {
+        return request(
+          assignConversationContract as ApiContract<
+            AssignConversationInput,
+            ConversationAssignment
+          >,
+          input,
+          { pathParams: { id: conversationId } }
+        );
+      },
+    },
+    messages: {
+      /**
+       * GET /api/v1/chat/conversations/:id/messages
+       * List messages with optional cursor pagination.
+       */
+      async list(conversationId: string, params?: CursorPageParams): Promise<ListMessagesResponse> {
+        return request(
+          listMessagesContract as ApiContract<CursorPageParams, ListMessagesResponse>,
+          params,
+          { pathParams: { id: conversationId } }
+        );
+      },
+
+      /**
+       * POST /api/v1/chat/conversations/:id/messages
+       * Send a message (idempotent via dedupeKey).
+       */
+      async send(conversationId: string, payload: CreateMessageInput): Promise<Message> {
+        return request(sendMessageContract as ApiContract<CreateMessageInput, Message>, payload, {
+          pathParams: { id: conversationId },
+        });
+      },
+
+      /**
+       * PATCH /api/v1/chat/messages/:id/receipts
+       * Mark a message as read.
+       */
+      async markRead(
+        messageId: string,
+        input?: MessageReceiptUpdate
+      ): Promise<MessageReceiptUpdate> {
+        return request(
+          markReadContract as ApiContract<MessageReceiptUpdate, MessageReceiptUpdate>,
+          input ?? {},
+          { pathParams: { id: messageId } }
+        );
+      },
+    },
+  };
+}

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -38,6 +38,12 @@ export type ApiClientConfig = {
   fetch?: typeof fetch;
 };
 
+/** Options for contract-based requests (path param substitution, etc.). */
+export type RequestOptions = {
+  /** Substitute :paramName in contract.path with pathParams.paramName. */
+  pathParams?: Record<string, string>;
+};
+
 /** Thrown when the API returns a non-2xx status or response fails validation. */
 export class ApiError extends Error {
   constructor(
@@ -65,17 +71,47 @@ export function createApiClient(config: ApiClientConfig) {
    *
    * When getAuthHeaders is configured, it is called before each request and its
    * result is merged with static headers (auth headers take precedence).
+   *
+   * Path params: Pass options.pathParams to substitute :paramName in the path
+   * (e.g. pathParams: { id: "uuid" } for /api/v1/chat/conversations/:id).
+   *
+   * GET requests: When requestData is a plain object, it is serialized as
+   * query string (e.g. { cursor: "x", limit: 20 } -> ?cursor=x&limit=20).
    */
-  async function request<T>(contract: ApiContract<unknown, T>, requestData?: unknown): Promise<T> {
+  async function request<T>(
+    contract: ApiContract<unknown, T>,
+    requestData?: unknown,
+    options?: RequestOptions
+  ): Promise<T> {
     const authHeaders = config.getAuthHeaders ? await config.getAuthHeaders() : {};
-    const url = `${baseUrl}${contract.path}`;
+    let path = contract.path;
+    if (options?.pathParams) {
+      for (const [key, value] of Object.entries(options.pathParams)) {
+        path = path.replace(`:${key}`, encodeURIComponent(value));
+      }
+    }
+    let url = `${baseUrl}${path}`;
     const init: RequestInit = {
       method: contract.method,
       headers: { 'Content-Type': 'application/json', ...staticHeaders, ...authHeaders },
     };
 
-    if (requestData !== undefined && contract.method !== 'GET') {
-      init.body = JSON.stringify(requestData);
+    if (requestData !== undefined) {
+      if (contract.method === 'GET') {
+        const params = new URLSearchParams();
+        const obj = requestData as Record<string, unknown>;
+        if (obj && typeof obj === 'object' && !Array.isArray(obj)) {
+          for (const [k, v] of Object.entries(obj)) {
+            if (v !== undefined && v !== null) {
+              params.set(k, String(v));
+            }
+          }
+        }
+        const query = params.toString();
+        if (query) url += `?${query}`;
+      } else {
+        init.body = JSON.stringify(requestData);
+      }
     }
 
     const res = await doFetch(url, init);

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -15,9 +15,16 @@
  *   });
  *   const user = await api.auth.whoami();
  */
-export { createApiClient, ApiError, type ApiClientConfig, type ApiContract } from './client';
+export {
+  createApiClient,
+  ApiError,
+  type ApiClientConfig,
+  type ApiContract,
+  type RequestOptions,
+} from './client';
 export { createHealthApi } from './health';
 export { createAuthApi } from './auth';
+export { createChatApi } from './chat';
 export type { PingResponse } from '@myclup/contracts/health';
 export type {
   WhoamiResponse,
@@ -25,10 +32,24 @@ export type {
   ProfilePatchRequest,
   ProfilePatchResponse,
 } from '@myclup/contracts/auth';
+export type {
+  AssignConversationInput,
+  Conversation,
+  ConversationAssignment,
+  CreateConversationInput,
+  CreateMessageInput,
+  CursorPageParams,
+  CursorPageResult,
+  GetConversationResponse,
+  Message,
+  MessageReceiptUpdate,
+  TypingState,
+} from '@myclup/contracts/chat';
 
 import { createApiClient } from './client';
 import { createHealthApi } from './health';
 import { createAuthApi } from './auth';
+import { createChatApi } from './chat';
 import type { ApiClientConfig } from './client';
 
 /**
@@ -42,11 +63,13 @@ import type { ApiClientConfig } from './client';
  * });
  * const result = await api.health.ping();
  * const user = await api.auth.whoami();
+ * const conversations = await api.chat.conversations.list();
  */
 export function createApi(config: ApiClientConfig) {
   const client = createApiClient(config);
   return {
     health: createHealthApi(client.request),
     auth: createAuthApi(client.request),
+    chat: createChatApi(client.request),
   };
 }


### PR DESCRIPTION
Closes #100

**Part of Epic #17**

## Summary
Add typed chat methods to packages/api-client for conversation list, get, create, assign, message list, send, mark read.

- conversations.list(), conversations.get(id), conversations.create(), conversations.assign()
- messages.list(conversationId, params), messages.send(), messages.markRead()
- Path param substitution and GET query params support in client
- All methods use contracts from packages/contracts

## Validation
- pnpm build passes
- All 20 api-client tests pass

Made with [Cursor](https://cursor.com)