### PR TITLE
feat(issue-126): membership and finance audit hooks

### DIFF
--- a/apps/web-gym-admin/src/server/billing/index.test.ts
+++ b/apps/web-gym-admin/src/server/billing/index.test.ts
@@ -66,7 +66,14 @@ describe('billing server module', () => {
     vi.clearAllMocks();
     vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://test.supabase.co');
     vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'service-role-key');
-    mockCreateServerClient.mockReturnValue({} as never);
+    const mockClient = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ data: [{ role: 'gym_manager', gym_id: validUuid }] }),
+        }),
+      }),
+    };
+    mockCreateServerClient.mockReturnValue(mockClient as never);
     mockGetCurrentUser.mockResolvedValue(mockUser);
     mockResolveTenantScope.mockResolvedValue([{ gymId: validUuid, branchId: null }]);
     mockRequirePermission.mockResolvedValue(undefined);
@@ -109,7 +116,42 @@ describe('billing server module', () => {
 
     expect(result?.id).toBe(validUuid);
     expect(mockRequirePermission).toHaveBeenCalled();
-    expect(mockWriteAuditEvent).toHaveBeenCalled();
+    expect(mockWriteAuditEvent.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('writes before/after refund audits for refunded payment logging', async () => {
+    mockLogPayment.mockResolvedValue({
+      id: validUuid,
+      gymId: validUuid,
+      branchId: null,
+      memberId: validUuid,
+      invoiceId: validUuid,
+      currency: 'TRY',
+      amount: 1000,
+      method: 'card',
+      status: 'refunded',
+      paidAt: '2025-03-19T12:00:00.000Z',
+      createdAt: '2025-03-19T12:00:00.000Z',
+      updatedAt: '2025-03-19T12:00:00.000Z',
+    });
+
+    const req = new NextRequest('http://localhost:3001/api/v1/billing/payments');
+    const result = await logPaymentServer(req, {
+      gymId: validUuid,
+      memberId: validUuid,
+      invoiceId: validUuid,
+      currency: 'TRY',
+      amount: 1000,
+      method: 'card',
+      status: 'refunded',
+      overrideReason: 'refund request',
+    });
+
+    expect(result?.status).toBe('refunded');
+    const refundCalls = mockWriteAuditEvent.mock.calls.filter(
+      ([, payload]) => payload.event_type === supabase.AUDIT_EVENT_TYPES.refund
+    );
+    expect(refundCalls.length).toBeGreaterThanOrEqual(2);
   });
 
   it('throws forbidden when settling receivable without tenant scope', async () => {

--- a/apps/web-gym-admin/src/server/billing/index.ts
+++ b/apps/web-gym-admin/src/server/billing/index.ts
@@ -41,6 +41,7 @@ import {
   triggerPaymentReminder,
   writeAuditEvent,
 } from '@myclup/supabase';
+import type { TenantScope } from '@myclup/types';
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL || '';
 const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
@@ -62,6 +63,21 @@ async function writeBillingAudit(
   } catch (error) {
     console.error('[billing] audit write failed', error);
   }
+}
+
+async function getActorRole(
+  client: ReturnType<typeof getClient>,
+  userId: string,
+  scope: TenantScope
+): Promise<string> {
+  const { data } = await client
+    .from('user_role_assignments')
+    .select('role, gym_id')
+    .eq('user_id', userId);
+  const rows = data ?? [];
+  const platform = rows.find((row) => row.role === 'platform_admin' && row.gym_id === null);
+  if (platform) return 'platform_admin';
+  return rows.find((row) => row.gym_id === scope.gymId)?.role ?? 'staff';
 }
 
 function parseLimitCursor(req: NextRequest) {
@@ -180,6 +196,8 @@ export async function logPaymentServer(
 ): Promise<LogPaymentResponse | null> {
   const scoped = await ensureScopeForWrite(req, input.gymId, input.branchId);
   if (!scoped) return null;
+  const actorRole = await getActorRole(scoped.client, scoped.currentUser.user.id, scoped.scope);
+  const timestamp = new Date().toISOString();
 
   if (input.overrideReason) {
     await requirePermission(
@@ -198,6 +216,12 @@ export async function logPaymentServer(
         previous_state: 'unpaid',
         new_state: input.status,
         reason: input.overrideReason,
+        actor_role: actorRole,
+        tenant_id: scoped.scope.gymId,
+        action: 'billing_override',
+        before_state: 'unpaid',
+        after_state: input.status,
+        timestamp,
       },
       tenant_context: { gym_id: scoped.scope.gymId, branch_id: scoped.scope.branchId ?? undefined },
     });
@@ -213,6 +237,12 @@ export async function logPaymentServer(
         payment_id: input.invoiceId,
         amount_cents: Math.round(input.amount * 100),
         reason: input.overrideReason,
+        actor_role: actorRole,
+        tenant_id: scoped.scope.gymId,
+        action: 'refund',
+        before_state: 'paid',
+        after_state: 'pending_refund',
+        timestamp,
       },
       tenant_context: { gym_id: scoped.scope.gymId, branch_id: scoped.scope.branchId ?? undefined },
     });
@@ -235,6 +265,12 @@ export async function logPaymentServer(
         previous_state: 'unpaid',
         new_state: payment.status,
         reason: input.overrideReason,
+        actor_role: actorRole,
+        tenant_id: payment.gymId,
+        action: 'billing_override',
+        before_state: 'unpaid',
+        after_state: payment.status,
+        timestamp: new Date().toISOString(),
       },
       tenant_context: { gym_id: payment.gymId, branch_id: payment.branchId ?? undefined },
     });
@@ -250,6 +286,12 @@ export async function logPaymentServer(
         payment_id: payment.id,
         amount_cents: Math.round(payment.amount * 100),
         reason: input.overrideReason,
+        actor_role: actorRole,
+        tenant_id: payment.gymId,
+        action: 'refund',
+        before_state: 'pending_refund',
+        after_state: 'refunded',
+        timestamp: new Date().toISOString(),
       },
       tenant_context: { gym_id: payment.gymId, branch_id: payment.branchId ?? undefined },
     });

--- a/apps/web-gym-admin/src/server/membership/instances.test.ts
+++ b/apps/web-gym-admin/src/server/membership/instances.test.ts
@@ -11,6 +11,7 @@ vi.mock('@myclup/supabase', async (importOriginal) => {
     resolveTenantScope: vi.fn(),
     requirePermission: vi.fn(),
     getMembershipInstance: vi.fn(),
+    listMembershipInstances: vi.fn(),
     assignMembershipInstance: vi.fn(),
     renewMembership: vi.fn(),
     freezeMembership: vi.fn(),
@@ -20,7 +21,13 @@ vi.mock('@myclup/supabase', async (importOriginal) => {
   };
 });
 
-import { assignInstance, cancelInstance, renewInstance, validateInstanceAccess } from './instances';
+import {
+  assignInstance,
+  cancelInstance,
+  listInstances,
+  renewInstance,
+  validateInstanceAccess,
+} from './instances';
 import * as supabase from '@myclup/supabase';
 
 const mockGetCurrentUser = vi.mocked(supabase.getCurrentUser);
@@ -28,6 +35,7 @@ const mockCreateServerClient = vi.mocked(supabase.createServerClient);
 const mockResolveTenantScope = vi.mocked(supabase.resolveTenantScope);
 const mockRequirePermission = vi.mocked(supabase.requirePermission);
 const mockGetMembershipInstance = vi.mocked(supabase.getMembershipInstance);
+const mockListMembershipInstances = vi.mocked(supabase.listMembershipInstances);
 const mockRenewMembership = vi.mocked(supabase.renewMembership);
 const mockCancelMembership = vi.mocked(supabase.cancelMembership);
 const mockValidateMembershipAccess = vi.mocked(supabase.validateMembershipAccess);
@@ -56,7 +64,14 @@ describe('membership instances server', () => {
     vi.clearAllMocks();
     vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://test.supabase.co');
     vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'service-role-key');
-    mockCreateServerClient.mockReturnValue({} as never);
+    const mockClient = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ data: [{ role: 'gym_manager', gym_id: validUuid }] }),
+        }),
+      }),
+    };
+    mockCreateServerClient.mockReturnValue(mockClient as never);
     mockGetCurrentUser.mockResolvedValue(mockUser);
     mockResolveTenantScope.mockResolvedValue([{ gymId: validUuid, branchId: null }]);
     mockRequirePermission.mockResolvedValue(undefined);
@@ -143,7 +158,7 @@ describe('membership instances server', () => {
     });
 
     expect(result?.cancelled).toBe(true);
-    expect(mockWriteAuditEvent).toHaveBeenCalled();
+    expect(mockWriteAuditEvent.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 
   it('writes denied-access audit on failed validation', async () => {
@@ -220,5 +235,26 @@ describe('membership instances server', () => {
 
     expect(mockRequirePermission).toHaveBeenCalled();
     expect(mockRenewMembership).toHaveBeenCalled();
+  });
+
+  it('writes cross-tenant audit for platform admin membership reads', async () => {
+    mockCreateServerClient.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ data: [{ role: 'platform_admin', gym_id: null }] }),
+        }),
+      }),
+    } as never);
+    mockListMembershipInstances.mockResolvedValue({ items: [], nextCursor: null });
+
+    const req = new NextRequest(
+      `http://localhost/api/v1/memberships/instances?gymId=${validUuid}&limit=20`
+    );
+    await listInstances(req);
+
+    const crossTenantCall = mockWriteAuditEvent.mock.calls.find(
+      ([, payload]) => payload.event_type === supabase.AUDIT_EVENT_TYPES.cross_tenant_support
+    );
+    expect(crossTenantCall).toBeDefined();
   });
 });

--- a/apps/web-gym-admin/src/server/membership/instances.ts
+++ b/apps/web-gym-admin/src/server/membership/instances.ts
@@ -29,6 +29,7 @@ import {
   validateMembershipAccess,
   writeAuditEvent,
 } from '@myclup/supabase';
+import type { TenantScope } from '@myclup/types';
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL || '';
 const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
@@ -66,6 +67,29 @@ async function writeMembershipAudit(
   }
 }
 
+type ActorContext = {
+  actorRole: string;
+  isPlatformAdmin: boolean;
+};
+
+async function getActorContext(
+  client: ReturnType<typeof getClient>,
+  userId: string,
+  scope: TenantScope
+): Promise<ActorContext> {
+  const { data } = await client
+    .from('user_role_assignments')
+    .select('role, gym_id')
+    .eq('user_id', userId);
+  const rows = data ?? [];
+  const platform = rows.find((row) => row.role === 'platform_admin' && row.gym_id === null);
+  if (platform) {
+    return { actorRole: 'platform_admin', isPlatformAdmin: true };
+  }
+  const gymRole = rows.find((row) => row.gym_id === scope.gymId)?.role;
+  return { actorRole: gymRole ?? 'staff', isPlatformAdmin: false };
+}
+
 export async function listInstances(
   req: NextRequest
 ): Promise<ListMembershipInstancesResponse | null> {
@@ -87,6 +111,27 @@ export async function listInstances(
 
   const scope = scopes[0];
   await requirePermission(client, currentUser.user.id, scope, 'members:read');
+  const actor = await getActorContext(client, currentUser.user.id, scope);
+  if (actor.isPlatformAdmin && params.gymId) {
+    const timestamp = new Date().toISOString();
+    await writeMembershipAudit(client, {
+      event_type: AUDIT_EVENT_TYPES.cross_tenant_support,
+      actor_id: currentUser.user.id,
+      target_type: 'membership_instances',
+      target_id: null,
+      payload: {
+        target_gym_id: scope.gymId,
+        target_branch_id: scope.branchId ?? undefined,
+        action: 'membership_list_access',
+        actor_role: actor.actorRole,
+        tenant_id: scope.gymId,
+        before_state: 'request_received',
+        after_state: 'scope_granted',
+        timestamp,
+      },
+      tenant_context: { gym_id: scope.gymId, branch_id: scope.branchId ?? undefined },
+    });
+  }
   return listMembershipInstances(client, {
     ...params,
     gymId: scope.gymId,
@@ -116,6 +161,8 @@ export async function assignInstance(
   }
   const scope = scopes[0];
   await requirePermission(client, currentUser.user.id, scope, 'members:write');
+  const actor = await getActorContext(client, currentUser.user.id, scope);
+  const timestamp = new Date().toISOString();
 
   const assigned = await assignMembershipInstance(client, {
     ...input,
@@ -135,6 +182,12 @@ export async function assignInstance(
       plan_id: assigned.planId,
       valid_from: assigned.validFrom,
       valid_until: assigned.validUntil,
+      actor_role: actor.actorRole,
+      tenant_id: assigned.gymId,
+      action: 'membership_assignment',
+      before_state: 'not_assigned',
+      after_state: assigned.status,
+      timestamp,
     },
     tenant_context: { gym_id: assigned.gymId, branch_id: assigned.branchId ?? undefined },
   });
@@ -162,12 +215,35 @@ export async function renewInstance(
     current.branchId ?? undefined
   );
   if (scopes.length === 0) throw new ForbiddenError('No tenant scope for membership renewal');
-  await requirePermission(client, currentUser.user.id, scopes[0], 'members:write');
+  const scope = scopes[0];
+  await requirePermission(client, currentUser.user.id, scope, 'members:write');
+  const actor = await getActorContext(client, currentUser.user.id, scope);
+  const timestamp = new Date().toISOString();
+
+  await writeMembershipAudit(client, {
+    event_type: AUDIT_EVENT_TYPES.membership_extension,
+    actor_id: currentUser.user.id,
+    target_type: 'membership_instances',
+    target_id: current.id,
+    payload: {
+      membership_id: current.id,
+      previous_end_at: current.validUntil ?? undefined,
+      new_end_at: input.renewedUntil,
+      reason: undefined,
+      actor_role: actor.actorRole,
+      tenant_id: current.gymId,
+      action: 'membership_manual_extension',
+      before_state: current.status,
+      after_state: 'pending_extension',
+      timestamp,
+    },
+    tenant_context: { gym_id: current.gymId, branch_id: current.branchId ?? undefined },
+  });
 
   const renewed = await renewMembership(client, instanceId, input);
 
   await writeMembershipAudit(client, {
-    event_type: AUDIT_EVENT_TYPES.membership_renewal,
+    event_type: AUDIT_EVENT_TYPES.membership_extension,
     actor_id: currentUser.user.id,
     target_type: 'membership_instances',
     target_id: renewed.membership.id,
@@ -175,7 +251,13 @@ export async function renewInstance(
       membership_id: renewed.membership.id,
       previous_end_at: current.validUntil,
       new_end_at: renewed.membership.validUntil,
-      added_session_count: input.addedSessionCount,
+      reason: undefined,
+      actor_role: actor.actorRole,
+      tenant_id: renewed.membership.gymId,
+      action: 'membership_manual_extension',
+      before_state: current.status,
+      after_state: renewed.membership.status,
+      timestamp: new Date().toISOString(),
     },
     tenant_context: {
       gym_id: renewed.membership.gymId,
@@ -206,7 +288,30 @@ export async function freezeInstance(
     current.branchId ?? undefined
   );
   if (scopes.length === 0) throw new ForbiddenError('No tenant scope for membership freeze');
-  await requirePermission(client, currentUser.user.id, scopes[0], 'members:write');
+  const scope = scopes[0];
+  await requirePermission(client, currentUser.user.id, scope, 'members:write');
+  const actor = await getActorContext(client, currentUser.user.id, scope);
+  const timestamp = new Date().toISOString();
+
+  await writeMembershipAudit(client, {
+    event_type: AUDIT_EVENT_TYPES.membership_freeze,
+    actor_id: currentUser.user.id,
+    target_type: 'membership_instances',
+    target_id: current.id,
+    payload: {
+      membership_id: current.id,
+      freeze_start_at: input.freezeStartAt,
+      freeze_end_at: input.freezeEndAt,
+      reason: input.reason,
+      actor_role: actor.actorRole,
+      tenant_id: current.gymId,
+      action: 'membership_freeze',
+      before_state: current.status,
+      after_state: 'pending_freeze',
+      timestamp,
+    },
+    tenant_context: { gym_id: current.gymId, branch_id: current.branchId ?? undefined },
+  });
 
   const frozen = await freezeMembership(client, instanceId, input);
 
@@ -220,6 +325,12 @@ export async function freezeInstance(
       freeze_start_at: input.freezeStartAt,
       freeze_end_at: input.freezeEndAt,
       reason: input.reason,
+      actor_role: actor.actorRole,
+      tenant_id: frozen.membership.gymId,
+      action: 'membership_freeze',
+      before_state: current.status,
+      after_state: frozen.membership.status,
+      timestamp: new Date().toISOString(),
     },
     tenant_context: {
       gym_id: frozen.membership.gymId,
@@ -250,7 +361,29 @@ export async function cancelInstance(
     current.branchId ?? undefined
   );
   if (scopes.length === 0) throw new ForbiddenError('No tenant scope for membership cancellation');
-  await requirePermission(client, currentUser.user.id, scopes[0], 'members:write');
+  const scope = scopes[0];
+  await requirePermission(client, currentUser.user.id, scope, 'members:write');
+  const actor = await getActorContext(client, currentUser.user.id, scope);
+  const timestamp = new Date().toISOString();
+
+  await writeMembershipAudit(client, {
+    event_type: AUDIT_EVENT_TYPES.membership_cancellation,
+    actor_id: currentUser.user.id,
+    target_type: 'membership_instances',
+    target_id: current.id,
+    payload: {
+      membership_id: current.id,
+      cancelled_at: input.cancelledAt,
+      reason: input.reason,
+      actor_role: actor.actorRole,
+      tenant_id: current.gymId,
+      action: 'membership_cancellation',
+      before_state: current.status,
+      after_state: 'pending_cancellation',
+      timestamp,
+    },
+    tenant_context: { gym_id: current.gymId, branch_id: current.branchId ?? undefined },
+  });
 
   const cancelled = await cancelMembership(client, instanceId, input.cancelledAt);
 
@@ -263,6 +396,12 @@ export async function cancelInstance(
       membership_id: cancelled.membership.id,
       cancelled_at: input.cancelledAt,
       reason: input.reason,
+      actor_role: actor.actorRole,
+      tenant_id: cancelled.membership.gymId,
+      action: 'membership_cancellation',
+      before_state: current.status,
+      after_state: cancelled.membership.status,
+      timestamp: new Date().toISOString(),
     },
     tenant_context: {
       gym_id: cancelled.membership.gymId,
@@ -294,7 +433,9 @@ export async function validateInstanceAccess(
   );
   if (scopes.length === 0)
     throw new ForbiddenError('No tenant scope for membership access validation');
-  await requirePermission(client, currentUser.user.id, scopes[0], 'members:read');
+  const scope = scopes[0];
+  await requirePermission(client, currentUser.user.id, scope, 'members:read');
+  const actor = await getActorContext(client, currentUser.user.id, scope);
 
   const result = await validateMembershipAccess(client, instanceId, input.branchId, input.at);
 
@@ -308,6 +449,12 @@ export async function validateInstanceAccess(
         membership_id: instanceId,
         branch_id: input.branchId,
         reason: result.reason,
+        actor_role: actor.actorRole,
+        tenant_id: current.gymId,
+        action: 'membership_access_validation',
+        before_state: current.status,
+        after_state: result.status,
+        timestamp: new Date().toISOString(),
       },
       tenant_context: {
         gym_id: current.gymId,

--- a/apps/web-gym-admin/src/server/membership/plans.test.ts
+++ b/apps/web-gym-admin/src/server/membership/plans.test.ts
@@ -15,6 +15,7 @@ vi.mock('@myclup/supabase', async (importOriginal) => {
     getMembershipPlan: vi.fn(),
     updateMembershipPlan: vi.fn(),
     deactivateMembershipPlan: vi.fn(),
+    writeAuditEvent: vi.fn(),
   };
 });
 
@@ -53,7 +54,14 @@ describe('membership plans server', () => {
     vi.clearAllMocks();
     vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://test.supabase.co');
     vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'service-role-key');
-    mockCreateServerClient.mockReturnValue({} as never);
+    const mockClient = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ data: [{ role: 'gym_manager', gym_id: validUuid }] }),
+        }),
+      }),
+    };
+    mockCreateServerClient.mockReturnValue(mockClient as never);
     mockGetCurrentUser.mockResolvedValue(mockUser);
     mockResolveTenantScope.mockResolvedValue([{ gymId: validUuid, branchId: null }]);
     mockRequirePermission.mockResolvedValue(undefined);

--- a/apps/web-gym-admin/src/server/membership/plans.ts
+++ b/apps/web-gym-admin/src/server/membership/plans.ts
@@ -9,6 +9,7 @@ import type {
   UpdateMembershipPlanResponse,
 } from '@myclup/contracts/membership';
 import {
+  AUDIT_EVENT_TYPES,
   createMembershipPlan,
   createServerClient,
   deactivateMembershipPlan,
@@ -19,6 +20,7 @@ import {
   requirePermission,
   resolveTenantScope,
   updateMembershipPlan,
+  writeAuditEvent,
 } from '@myclup/supabase';
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL || '';
@@ -29,6 +31,17 @@ function getClient() {
     supabaseUrl: SUPABASE_URL,
     serviceRoleKey: SERVICE_ROLE_KEY,
   });
+}
+
+async function writeMembershipAudit(
+  client: ReturnType<typeof getClient>,
+  params: Parameters<typeof writeAuditEvent>[1]
+) {
+  try {
+    await writeAuditEvent(client, params);
+  } catch (error) {
+    console.error('[membership-plans] audit write failed', error);
+  }
 }
 
 function parseListParams(req: NextRequest): ListMembershipPlansRequest {
@@ -59,6 +72,32 @@ export async function listPlans(req: NextRequest): Promise<ListMembershipPlansRe
 
   const scope = scopes[0];
   await requirePermission(client, currentUser.user.id, scope, 'members:read');
+  const { data } = await client
+    .from('user_role_assignments')
+    .select('role, gym_id')
+    .eq('user_id', currentUser.user.id);
+  const isPlatformAdmin = (data ?? []).some(
+    (row) => row.role === 'platform_admin' && row.gym_id === null
+  );
+  if (isPlatformAdmin && params.gymId) {
+    await writeMembershipAudit(client, {
+      event_type: AUDIT_EVENT_TYPES.cross_tenant_support,
+      actor_id: currentUser.user.id,
+      target_type: 'membership_plans',
+      target_id: null,
+      payload: {
+        target_gym_id: scope.gymId,
+        target_branch_id: scope.branchId ?? undefined,
+        action: 'membership_plan_list_access',
+        actor_role: 'platform_admin',
+        tenant_id: scope.gymId,
+        before_state: 'request_received',
+        after_state: 'scope_granted',
+        timestamp: new Date().toISOString(),
+      },
+      tenant_context: { gym_id: scope.gymId, branch_id: scope.branchId ?? undefined },
+    });
+  }
   return listMembershipPlans(client, {
     ...params,
     gymId: scope.gymId,

--- a/packages/supabase/src/audit/schemas.ts
+++ b/packages/supabase/src/audit/schemas.ts
@@ -11,6 +11,15 @@ import type { AuditEventType } from './event-types';
 /** UUID string format */
 const uuidSchema = z.string().uuid();
 
+const auditMetadataSchema = z.object({
+  actor_role: z.string().optional(),
+  tenant_id: uuidSchema.optional(),
+  action: z.string().optional(),
+  before_state: z.string().optional(),
+  after_state: z.string().optional(),
+  timestamp: z.string().optional(),
+});
+
 /** Role change: assignment modified (e.g. user_role_assignments, gym_staff) */
 export const roleChangePayloadSchema = z.object({
   assignment_type: z.enum(['user_role_assignments', 'gym_staff']),
@@ -20,61 +29,77 @@ export const roleChangePayloadSchema = z.object({
 });
 
 /** Billing override: manual override of billing state */
-export const billingOverridePayloadSchema = z.object({
-  subscription_id: z.string().optional(),
-  previous_state: z.string().optional(),
-  new_state: z.string(),
-  reason: z.string().optional(),
-});
+export const billingOverridePayloadSchema = z
+  .object({
+    subscription_id: z.string().optional(),
+    previous_state: z.string().optional(),
+    new_state: z.string(),
+    reason: z.string().optional(),
+  })
+  .merge(auditMetadataSchema);
 
 /** Membership extension: manual extension of membership validity */
-export const membershipExtensionPayloadSchema = z.object({
-  membership_id: uuidSchema,
-  previous_end_at: z.string().optional(),
-  new_end_at: z.string(),
-  reason: z.string().optional(),
-});
+export const membershipExtensionPayloadSchema = z
+  .object({
+    membership_id: uuidSchema,
+    previous_end_at: z.string().optional(),
+    new_end_at: z.string(),
+    reason: z.string().optional(),
+  })
+  .merge(auditMetadataSchema);
 
-export const membershipAssignmentPayloadSchema = z.object({
-  membership_id: uuidSchema,
-  member_id: uuidSchema,
-  plan_id: uuidSchema,
-  valid_from: z.string(),
-  valid_until: z.string().nullable(),
-});
+export const membershipAssignmentPayloadSchema = z
+  .object({
+    membership_id: uuidSchema,
+    member_id: uuidSchema,
+    plan_id: uuidSchema,
+    valid_from: z.string(),
+    valid_until: z.string().nullable(),
+  })
+  .merge(auditMetadataSchema);
 
-export const membershipRenewalPayloadSchema = z.object({
-  membership_id: uuidSchema,
-  previous_end_at: z.string().nullable(),
-  new_end_at: z.string(),
-  added_session_count: z.number().int().nonnegative().optional(),
-});
+export const membershipRenewalPayloadSchema = z
+  .object({
+    membership_id: uuidSchema,
+    previous_end_at: z.string().nullable(),
+    new_end_at: z.string(),
+    added_session_count: z.number().int().nonnegative().optional(),
+  })
+  .merge(auditMetadataSchema);
 
-export const membershipFreezePayloadSchema = z.object({
-  membership_id: uuidSchema,
-  freeze_start_at: z.string(),
-  freeze_end_at: z.string(),
-  reason: z.string().optional(),
-});
+export const membershipFreezePayloadSchema = z
+  .object({
+    membership_id: uuidSchema,
+    freeze_start_at: z.string(),
+    freeze_end_at: z.string(),
+    reason: z.string().optional(),
+  })
+  .merge(auditMetadataSchema);
 
-export const membershipCancellationPayloadSchema = z.object({
-  membership_id: uuidSchema,
-  cancelled_at: z.string(),
-  reason: z.string().optional(),
-});
+export const membershipCancellationPayloadSchema = z
+  .object({
+    membership_id: uuidSchema,
+    cancelled_at: z.string(),
+    reason: z.string().optional(),
+  })
+  .merge(auditMetadataSchema);
 
-export const membershipAccessDeniedPayloadSchema = z.object({
-  membership_id: uuidSchema,
-  branch_id: uuidSchema,
-  reason: z.enum(['expired', 'cancelled', 'frozen', 'branch_not_entitled']),
-});
+export const membershipAccessDeniedPayloadSchema = z
+  .object({
+    membership_id: uuidSchema,
+    branch_id: uuidSchema,
+    reason: z.enum(['expired', 'cancelled', 'frozen', 'branch_not_entitled']),
+  })
+  .merge(auditMetadataSchema);
 
 /** Refund: refund processed */
-export const refundPayloadSchema = z.object({
-  payment_id: z.string().optional(),
-  amount_cents: z.number().int().nonnegative().optional(),
-  reason: z.string().optional(),
-});
+export const refundPayloadSchema = z
+  .object({
+    payment_id: z.string().optional(),
+    amount_cents: z.number().int().nonnegative().optional(),
+    reason: z.string().optional(),
+  })
+  .merge(auditMetadataSchema);
 
 /** Admin impersonation: platform/admin impersonates another user */
 export const adminImpersonationPayloadSchema = z.object({
@@ -83,12 +108,14 @@ export const adminImpersonationPayloadSchema = z.object({
 });
 
 /** Cross-tenant support: platform support accesses another tenant */
-export const crossTenantSupportPayloadSchema = z.object({
-  target_gym_id: uuidSchema,
-  target_branch_id: uuidSchema.optional(),
-  action: z.string(),
-  reason: z.string().optional(),
-});
+export const crossTenantSupportPayloadSchema = z
+  .object({
+    target_gym_id: uuidSchema,
+    target_branch_id: uuidSchema.optional(),
+    action: z.string(),
+    reason: z.string().optional(),
+  })
+  .merge(auditMetadataSchema.omit({ action: true }));
 
 /** Chat assignment: staff assignment or reassignment of conversation */
 export const chatAssignmentPayloadSchema = z.object({


### PR DESCRIPTION
Closes #126
Part of Epic #18

## Summary
- add before/after audit hook emission for membership extension, freeze, cancellation, and access-denied validation flows
- emit cross-tenant support audit records for platform-admin membership reads in plans/instances listing paths
- enrich billing override/refund audit payloads with actor role, tenant id, action, before/after state, and timestamps
- keep audit writes non-blocking (graceful degradation) and add test coverage for new audit scenarios

## Acceptance Criteria Coverage
- [x] Membership extension/freeze/cancel/access-denied audit events emitted with before/after semantics
- [x] Billing override and refund emit audit events before and after operation
- [x] Cross-tenant membership read audit event emitted for platform admin access paths
- [x] Audit writes remain graceful (swallowed on failure)
- [x] Tests added/updated for sensitive audit scenarios

## Validation
- `pnpm --filter @myclup/supabase lint`
- `pnpm --filter @myclup/web-gym-admin lint`
- `pnpm --filter @myclup/web-gym-admin test`
- `pnpm --filter @myclup/web-gym-admin typecheck`
- `pnpm --filter @myclup/supabase typecheck`


Made with [Cursor](https://cursor.com)