### PR TITLE
feat(issue-137): add notifications reminder center

### DIFF
--- a/apps/mobile-user/app/notifications.tsx
+++ b/apps/mobile-user/app/notifications.tsx
@@ -1,0 +1,5 @@
+import { NotificationCenterScreen } from '../src/features/notifications/NotificationCenterScreen';
+
+export default function NotificationsRoute() {
+  return <NotificationCenterScreen />;
+}

--- a/apps/mobile-user/src/features/home/HomeDashboardScreen.tsx
+++ b/apps/mobile-user/src/features/home/HomeDashboardScreen.tsx
@@ -277,6 +277,12 @@ export function HomeDashboardScreen() {
             <AppText variant="body" tone="muted">
               {tCommon('notificationsDashboard.body')}
             </AppText>
+            <AppButton
+              label={tCommon('cta.openNotifications')}
+              icon="bell-badge-outline"
+              variant="secondary"
+              onPress={() => router.push('/notifications')}
+            />
           </Card>
         </View>
       </ScrollView>

--- a/apps/mobile-user/src/features/home/homeDashboard.test.ts
+++ b/apps/mobile-user/src/features/home/homeDashboard.test.ts
@@ -33,4 +33,14 @@ describe('home dashboard helpers', () => {
       route: '/membership/renew',
     });
   });
+
+  it('keeps booking out of route wiring until scheduling is implemented', () => {
+    const quickActions = buildQuickActions();
+
+    expect(quickActions[0]).toMatchObject({
+      key: 'bookClass',
+      disabled: true,
+    });
+    expect(quickActions[0]?.route).toBeUndefined();
+  });
 });

--- a/apps/mobile-user/src/features/notifications/NotificationCenterScreen.tsx
+++ b/apps/mobile-user/src/features/notifications/NotificationCenterScreen.tsx
@@ -1,0 +1,260 @@
+import { useMemo } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { Card, ScreenContainer } from '@myclup/ui-native';
+import { useConversations } from '../chat/useConversations';
+import { useMembership } from '../membership/useMembership';
+import { AppButton } from '../../components/AppButton';
+import { AppIcon } from '../../components/AppIcon';
+import { AppSectionHeader } from '../../components/AppSectionHeader';
+import { AppStateBlock } from '../../components/AppStateBlock';
+import { AppStatusBadge } from '../../components/AppStatusBadge';
+import { AppText } from '../../components/AppText';
+import { appTheme } from '../../theme/appTheme';
+import { buildNotificationSignals } from './notificationCenter';
+
+export function NotificationCenterScreen() {
+  const router = useRouter();
+  const { t } = useTranslation('common');
+  const {
+    data: membershipData,
+    error: membershipError,
+    loading: membershipLoading,
+    refresh: refreshMembership,
+  } = useMembership();
+  const {
+    items: conversations,
+    error: conversationsError,
+    loading: conversationsLoading,
+    refresh: refreshConversations,
+  } = useConversations();
+
+  const notificationSignals = useMemo(
+    () =>
+      buildNotificationSignals({
+        renewalReason: membershipData.renewalReason,
+        conversations,
+      }),
+    [conversations, membershipData.renewalReason]
+  );
+
+  const unreadConversationCount = useMemo(
+    () => conversations.reduce((total, conversation) => total + (conversation.unreadCount ?? 0), 0),
+    [conversations]
+  );
+  const hasError = Boolean(membershipError || conversationsError);
+  const isLoading = membershipLoading || conversationsLoading;
+
+  return (
+    <ScreenContainer style={styles.screen}>
+      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+        <Card style={styles.heroCard}>
+          <View style={styles.heroTopRow}>
+            <AppStatusBadge label={t('dashboard.notificationsTitle')} tone="primary" />
+            <AppText variant="caption" tone="inverse" style={styles.heroMeta}>
+              {t('shell.subtitle')}
+            </AppText>
+          </View>
+          <View style={styles.heroBody}>
+            <AppText variant="title" tone="inverse">
+              {t('notifications.heroTitle')}
+            </AppText>
+            <AppText variant="subtitle" tone="inverse">
+              {t('notifications.heroSubtitle')}
+            </AppText>
+          </View>
+          <View style={styles.heroStats}>
+            <View style={styles.heroStat}>
+              <AppText variant="value" tone="inverse">
+                {unreadConversationCount}
+              </AppText>
+              <AppText variant="caption" tone="inverse">
+                {t('notifications.stats.unreadMessages')}
+              </AppText>
+            </View>
+            <View style={styles.heroStat}>
+              <AppText variant="value" tone="inverse">
+                {membershipData.renewalReason
+                  ? t('notifications.stats.actionNeeded')
+                  : t('notifications.stats.clear')}
+              </AppText>
+              <AppText variant="caption" tone="inverse">
+                {t('notifications.stats.membership')}
+              </AppText>
+            </View>
+          </View>
+        </Card>
+
+        <View style={styles.sectionGap}>
+          <AppSectionHeader
+            title={t('notifications.centerTitle')}
+            subtitle={t('notifications.centerSubtitle')}
+          />
+          {isLoading ? (
+            <AppStateBlock
+              loading
+              title={t('notifications.loadingTitle')}
+              description={t('notifications.loadingBody')}
+            />
+          ) : hasError ? (
+            <AppStateBlock
+              icon="alert-circle-outline"
+              title={t('notifications.errorTitle')}
+              description={t('notifications.errorBody')}
+              actionLabel={t('cta.retry')}
+              onAction={() => {
+                void refreshMembership();
+                void refreshConversations();
+              }}
+            />
+          ) : (
+            <View style={styles.cardStack}>
+              {notificationSignals.map((signal) => (
+                <Card key={signal.key} style={styles.signalCard}>
+                  <View style={styles.signalHeader}>
+                    <View style={styles.signalIconWrap}>
+                      <AppIcon name={signal.icon} size={20} color={appTheme.colors.primary} />
+                    </View>
+                    <View style={styles.signalCopy}>
+                      <AppText variant="subtitle" style={styles.signalTitle}>
+                        {t(signal.titleKey)}
+                      </AppText>
+                      <AppText variant="body" tone="muted">
+                        {t(signal.bodyKey, { count: unreadConversationCount })}
+                      </AppText>
+                    </View>
+                  </View>
+                  <View style={styles.signalFooter}>
+                    <AppStatusBadge
+                      label={t(`notifications.status.${signal.tone}`)}
+                      tone={signal.tone}
+                    />
+                    {signal.actionRoute && signal.actionLabelKey ? (
+                      <AppButton
+                        label={t(signal.actionLabelKey)}
+                        variant="secondary"
+                        onPress={() => {
+                          if (signal.actionRoute) {
+                            router.push(signal.actionRoute);
+                          }
+                        }}
+                      />
+                    ) : null}
+                  </View>
+                </Card>
+              ))}
+            </View>
+          )}
+        </View>
+
+        <View style={styles.sectionGap}>
+          <AppSectionHeader
+            title={t('notifications.quickLinksTitle')}
+            subtitle={t('notifications.quickLinksSubtitle')}
+          />
+          <View style={styles.quickLinks}>
+            <AppButton
+              label={t('cta.openMembership')}
+              icon="credit-card-outline"
+              variant="secondary"
+              onPress={() => router.push('/membership')}
+            />
+            <AppButton
+              label={t('cta.openChat')}
+              icon="chat-outline"
+              variant="secondary"
+              onPress={() => router.push('/chat')}
+            />
+            <AppButton
+              label={t('cta.openProfile')}
+              icon="account-circle-outline"
+              variant="secondary"
+              onPress={() => router.push('/profile')}
+            />
+          </View>
+        </View>
+      </ScrollView>
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: appTheme.colors.background,
+    padding: 0,
+  },
+  content: {
+    paddingHorizontal: appTheme.spacing.xl,
+    paddingTop: appTheme.spacing.md,
+    paddingBottom: 36,
+    gap: appTheme.spacing.xl,
+  },
+  heroCard: {
+    backgroundColor: appTheme.colors.primary,
+    borderColor: 'rgba(255,255,255,0.16)',
+    gap: appTheme.spacing.lg,
+  },
+  heroTopRow: {
+    gap: 8,
+  },
+  heroMeta: {
+    opacity: 0.88,
+  },
+  heroBody: {
+    gap: 10,
+  },
+  heroStats: {
+    flexDirection: 'row',
+    gap: appTheme.spacing.md,
+    flexWrap: 'wrap',
+  },
+  heroStat: {
+    minWidth: 132,
+    gap: 4,
+    paddingHorizontal: appTheme.spacing.md,
+    paddingVertical: appTheme.spacing.sm,
+    borderRadius: appTheme.radii.lg,
+    backgroundColor: 'rgba(255,255,255,0.12)',
+  },
+  sectionGap: {
+    gap: appTheme.spacing.md,
+  },
+  cardStack: {
+    gap: appTheme.spacing.md,
+  },
+  signalCard: {
+    gap: appTheme.spacing.md,
+  },
+  signalHeader: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: appTheme.spacing.md,
+  },
+  signalIconWrap: {
+    width: 42,
+    height: 42,
+    borderRadius: appTheme.radii.pill,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: appTheme.colors.surfaceMuted,
+  },
+  signalCopy: {
+    flex: 1,
+    gap: 4,
+  },
+  signalTitle: {
+    fontWeight: '800',
+  },
+  signalFooter: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: appTheme.spacing.md,
+    flexWrap: 'wrap',
+  },
+  quickLinks: {
+    gap: appTheme.spacing.sm,
+  },
+});

--- a/apps/mobile-user/src/features/notifications/notificationCenter.test.ts
+++ b/apps/mobile-user/src/features/notifications/notificationCenter.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { buildNotificationSignals } from './notificationCenter';
+
+describe('notification center helpers', () => {
+  it('builds actionable membership and chat signals before placeholders', () => {
+    const items = buildNotificationSignals({
+      renewalReason: 'expired',
+      conversations: [
+        {
+          id: '11111111-1111-1111-1111-111111111111',
+          gymId: '22222222-2222-2222-2222-222222222222',
+          branchId: null,
+          type: 'support',
+          metadata: {},
+          createdAt: '2026-03-19T08:00:00.000Z',
+          updatedAt: '2026-03-19T09:00:00.000Z',
+          unreadCount: 3,
+        },
+      ],
+    });
+
+    expect(items.map((item) => item.key)).toEqual(['membership', 'chat', 'booking', 'updates']);
+    expect(items[0]).toMatchObject({
+      actionRoute: '/membership/renew',
+      actionLabelKey: 'cta.renewNow',
+      tone: 'warning',
+    });
+    expect(items[1]).toMatchObject({
+      actionRoute: '/chat',
+      actionLabelKey: 'cta.openChat',
+      tone: 'primary',
+    });
+  });
+
+  it('falls back to an all-caught-up signal when no actionable state exists', () => {
+    const items = buildNotificationSignals({
+      renewalReason: null,
+      conversations: [],
+    });
+
+    expect(items[0]).toMatchObject({
+      key: 'updates',
+      titleKey: 'notifications.caughtUpTitle',
+      tone: 'success',
+    });
+    expect(items[1]).toMatchObject({
+      key: 'booking',
+      tone: 'neutral',
+    });
+  });
+});

--- a/apps/mobile-user/src/features/notifications/notificationCenter.ts
+++ b/apps/mobile-user/src/features/notifications/notificationCenter.ts
@@ -1,0 +1,94 @@
+import type { ConversationWithUnread } from '../chat/useConversations';
+import type { RenewalReason } from '../membership/types';
+
+export type NotificationSignalTone = 'primary' | 'success' | 'warning' | 'neutral';
+
+export type NotificationSignal = {
+  key: 'membership' | 'chat' | 'booking' | 'updates';
+  icon: string;
+  titleKey: string;
+  bodyKey: string;
+  tone: NotificationSignalTone;
+  actionRoute?: '/membership' | '/membership/renew' | '/chat';
+  actionLabelKey?: string;
+};
+
+type BuildNotificationSignalsInput = {
+  renewalReason: RenewalReason;
+  conversations: ConversationWithUnread[];
+};
+
+export function buildNotificationSignals({
+  renewalReason,
+  conversations,
+}: BuildNotificationSignalsInput): NotificationSignal[] {
+  const unreadThreads = conversations.filter((conversation) => (conversation.unreadCount ?? 0) > 0);
+  const unreadCount = unreadThreads.reduce(
+    (total, conversation) => total + (conversation.unreadCount ?? 0),
+    0
+  );
+  const signals: NotificationSignal[] = [];
+
+  if (renewalReason) {
+    signals.push({
+      key: 'membership',
+      icon: renewalReason === 'expired' ? 'alert-circle-outline' : 'clock-alert-outline',
+      titleKey:
+        renewalReason === 'expired'
+          ? 'notifications.membershipExpiredTitle'
+          : 'notifications.membershipExpiringTitle',
+      bodyKey:
+        renewalReason === 'expired'
+          ? 'notifications.membershipExpiredBody'
+          : 'notifications.membershipExpiringBody',
+      tone: 'warning',
+      actionRoute: '/membership/renew',
+      actionLabelKey: 'cta.renewNow',
+    });
+  }
+
+  if (unreadCount > 0) {
+    signals.push({
+      key: 'chat',
+      icon: 'chat-processing-outline',
+      titleKey: 'notifications.chatUnreadTitle',
+      bodyKey:
+        unreadThreads.length > 1
+          ? 'notifications.chatUnreadBodyMany'
+          : 'notifications.chatUnreadBodySingle',
+      tone: 'primary',
+      actionRoute: '/chat',
+      actionLabelKey: 'cta.openChat',
+    });
+  }
+
+  if (signals.length === 0) {
+    signals.push({
+      key: 'updates',
+      icon: 'bell-check-outline',
+      titleKey: 'notifications.caughtUpTitle',
+      bodyKey: 'notifications.caughtUpBody',
+      tone: 'success',
+    });
+  }
+
+  signals.push({
+    key: 'booking',
+    icon: 'calendar-clock-outline',
+    titleKey: 'notifications.bookingPlaceholderTitle',
+    bodyKey: 'notifications.bookingPlaceholderBody',
+    tone: 'neutral',
+  });
+
+  if (!signals.some((signal) => signal.key === 'updates')) {
+    signals.push({
+      key: 'updates',
+      icon: 'bell-badge-outline',
+      titleKey: 'notifications.updatesPlaceholderTitle',
+      bodyKey: 'notifications.updatesPlaceholderBody',
+      tone: 'neutral',
+    });
+  }
+
+  return signals;
+}

--- a/packages/i18n/src/__tests__/common-notifications-keys.test.ts
+++ b/packages/i18n/src/__tests__/common-notifications-keys.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import commonEn from '../namespaces/common/en.json';
+import commonTr from '../namespaces/common/tr.json';
+
+function flattenKeys(value: Record<string, unknown>, prefix = ''): string[] {
+  return Object.entries(value).flatMap(([key, nestedValue]) => {
+    const currentKey = prefix ? `${prefix}.${key}` : key;
+    if (nestedValue && typeof nestedValue === 'object' && !Array.isArray(nestedValue)) {
+      return flattenKeys(nestedValue as Record<string, unknown>, currentKey);
+    }
+
+    return [currentKey];
+  });
+}
+
+describe('common notifications keys', () => {
+  it('keeps notifications/reminder copy in parity across locales', () => {
+    expect(flattenKeys({ notifications: commonTr.notifications } as Record<string, unknown>)).toEqual(
+      flattenKeys({ notifications: commonEn.notifications } as Record<string, unknown>)
+    );
+  });
+});

--- a/packages/i18n/src/namespaces/common/en.json
+++ b/packages/i18n/src/namespaces/common/en.json
@@ -83,8 +83,47 @@
   "cta": {
     "openMembership": "Open membership",
     "openChat": "Open chat",
+    "openNotifications": "Open notifications",
+    "openProfile": "Open profile",
     "renewNow": "Renew now",
     "retry": "Retry"
+  },
+  "notifications": {
+    "heroTitle": "Notifications and reminders",
+    "heroSubtitle": "See what needs your attention now, and what will land here once delivery channels go live.",
+    "centerTitle": "Member signal center",
+    "centerSubtitle": "Current reminders come from existing membership and chat data. Future transport-backed alerts stay explicit placeholders.",
+    "loadingTitle": "Loading notifications...",
+    "loadingBody": "Checking membership urgency and unread conversations.",
+    "errorTitle": "Notifications could not be loaded",
+    "errorBody": "Try again to refresh the latest member signals.",
+    "membershipExpiredTitle": "Membership has expired",
+    "membershipExpiredBody": "Renew now to restore access and keep the member surface current.",
+    "membershipExpiringTitle": "Membership is nearing renewal",
+    "membershipExpiringBody": "Renew before the access window closes to avoid interruption.",
+    "chatUnreadTitle": "Unread chat follow-up",
+    "chatUnreadBodySingle": "You have {{count}} unread message waiting in the latest conversation.",
+    "chatUnreadBodyMany": "You have {{count}} unread messages across active conversations.",
+    "caughtUpTitle": "All caught up",
+    "caughtUpBody": "There are no urgent member reminders right now. This center will keep future alerts in one place.",
+    "bookingPlaceholderTitle": "Booking reminders",
+    "bookingPlaceholderBody": "Class reminders and waitlist nudges will appear here after the booking surface is wired.",
+    "updatesPlaceholderTitle": "Push and campaign alerts",
+    "updatesPlaceholderBody": "Push, campaign, and app update alerts remain placeholders until delivery transport is enabled.",
+    "quickLinksTitle": "Keep moving",
+    "quickLinksSubtitle": "Jump directly into the member surfaces connected to these reminders.",
+    "stats": {
+      "unreadMessages": "Unread messages",
+      "actionNeeded": "Action needed",
+      "clear": "Clear",
+      "membership": "Membership"
+    },
+    "status": {
+      "primary": "Active signal",
+      "success": "Up to date",
+      "warning": "Needs action",
+      "neutral": "Coming next"
+    }
   },
   "profile": {
     "title": "Profile and settings",

--- a/packages/i18n/src/namespaces/common/tr.json
+++ b/packages/i18n/src/namespaces/common/tr.json
@@ -83,8 +83,47 @@
   "cta": {
     "openMembership": "Üyeliği aç",
     "openChat": "Sohbeti aç",
+    "openNotifications": "Bildirimleri aç",
+    "openProfile": "Profili aç",
     "renewNow": "Şimdi yenile",
     "retry": "Tekrar dene"
+  },
+  "notifications": {
+    "heroTitle": "Bildirimler ve hatırlatıcılar",
+    "heroSubtitle": "Şu anda ilgilenmeniz gerekenleri ve teslimat kanalları açıldığında burada görünecek alanları tek yerde görün.",
+    "centerTitle": "Üye sinyal merkezi",
+    "centerSubtitle": "Güncel hatırlatıcılar mevcut üyelik ve sohbet verilerinden gelir. Gelecekteki transport destekli uyarılar açık yer tutucular olarak kalır.",
+    "loadingTitle": "Bildirimler yükleniyor...",
+    "loadingBody": "Üyelik aciliyeti ve okunmamış görüşmeler kontrol ediliyor.",
+    "errorTitle": "Bildirimler yüklenemedi",
+    "errorBody": "En son üye sinyallerini yenilemek için tekrar deneyin.",
+    "membershipExpiredTitle": "Üyelik süresi doldu",
+    "membershipExpiredBody": "Erişimi geri kazanmak ve üye yüzeyini güncel tutmak için şimdi yenileyin.",
+    "membershipExpiringTitle": "Üyelik yenileme zamanı yaklaşıyor",
+    "membershipExpiringBody": "Kesinti yaşamamak için erişim penceresi kapanmadan yenileyin.",
+    "chatUnreadTitle": "Okunmamış sohbet takibi",
+    "chatUnreadBodySingle": "Son görüşmede sizi bekleyen {{count}} okunmamış mesaj var.",
+    "chatUnreadBodyMany": "Aktif görüşmelerde toplam {{count}} okunmamış mesaj var.",
+    "caughtUpTitle": "Her şey güncel",
+    "caughtUpBody": "Şu anda acil üye hatırlatıcısı yok. Bu merkez gelecekteki uyarıları tek yerde toplayacak.",
+    "bookingPlaceholderTitle": "Rezervasyon hatırlatıcıları",
+    "bookingPlaceholderBody": "Rezervasyon yüzeyi bağlandığında ders hatırlatmaları ve bekleme listesi uyarıları burada görünecek.",
+    "updatesPlaceholderTitle": "Push ve kampanya uyarıları",
+    "updatesPlaceholderBody": "Push, kampanya ve uygulama güncelleme uyarıları teslimat transport'u etkinleşene kadar yer tutucu olarak kalır.",
+    "quickLinksTitle": "Akışı sürdür",
+    "quickLinksSubtitle": "Bu hatırlatıcılarla bağlantılı üye yüzeylerine doğrudan geçin.",
+    "stats": {
+      "unreadMessages": "Okunmamış mesaj",
+      "actionNeeded": "Aksiyon gerekli",
+      "clear": "Temiz",
+      "membership": "Üyelik"
+    },
+    "status": {
+      "primary": "Aktif sinyal",
+      "success": "Güncel",
+      "warning": "Aksiyon gerekli",
+      "neutral": "Sıradaki"
+    }
   },
   "profile": {
     "title": "Profil ve ayarlar",


### PR DESCRIPTION
Closes #137

Epic: #30

Summary:
- add a dedicated member notifications route and signal center in `apps/mobile-user`
- reuse existing membership renewal and chat unread state instead of inventing unsupported transport data
- wire the home dashboard notification card into the new route with localized copy and tests

Acceptance Criteria:
- [x] Members can open a dedicated notifications/reminder center from the home surface
- [x] Notification cards reuse existing membership and chat state instead of inventing unsupported server data
- [x] Booking, push, and campaign reminder areas are present with explicit placeholder states where backend transport is not yet available
- [x] Visual language stays consistent with the shared app shell, font, and icon system
- [x] All new copy is translation-driven with locale parity coverage
- [x] Mobile layout remains usable on common phone widths

Validation:
- [x] `pnpm --filter @myclup/mobile-user lint`
- [x] `pnpm --filter @myclup/mobile-user typecheck`
- [x] `pnpm --filter @myclup/mobile-user test`
- [x] `pnpm --filter @myclup/i18n test`
