### PR TITLE
feat: align member chat surface with shared shell

### DIFF
--- a/apps/mobile-user/app/chat/[id].tsx
+++ b/apps/mobile-user/app/chat/[id].tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useLocalSearchParams } from 'expo-router';
+import { useTranslation } from 'react-i18next';
 import type { Message } from '@myclup/contracts/chat';
 import { MessageThread } from '../../src/features/chat/MessageThread';
 import { useMessages } from '../../src/features/chat/useMessages';
@@ -8,6 +9,7 @@ import { useCurrentUser } from '../../src/features/chat/useCurrentUser';
 
 export default function ChatDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
+  const { t } = useTranslation('chat');
   const conversationId = id ?? '';
   const currentUserId = useCurrentUser();
 
@@ -33,8 +35,6 @@ export default function ChatDetailScreen() {
     currentUserId,
     handleNewMessage
   );
-
-  const typingNames = typingUserIds.size > 0 ? ['Someone'] : [];
 
   const handleTypingChange = useCallback(
     (typing: boolean) => {
@@ -62,7 +62,7 @@ export default function ChatDetailScreen() {
       loading={loading}
       error={error}
       onSendMessage={handleSendMessage}
-      typingNames={typingNames}
+      typingLabel={typingUserIds.size > 0 ? t('label.typingSomeone') : null}
       onTypingChange={handleTypingChange}
     />
   );

--- a/apps/mobile-user/app/chat/index.tsx
+++ b/apps/mobile-user/app/chat/index.tsx
@@ -1,5 +1,6 @@
-import { View, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 import { useRouter } from 'expo-router';
+import { ScreenContainer } from '@myclup/ui-native';
 import { ConversationList } from '../../src/features/chat/ConversationList';
 import { useConversations } from '../../src/features/chat/useConversations';
 
@@ -12,7 +13,7 @@ export default function ChatIndexScreen() {
   };
 
   return (
-    <View style={styles.container}>
+    <ScreenContainer style={styles.container}>
       <ConversationList
         items={items}
         loading={loading}
@@ -22,7 +23,7 @@ export default function ChatIndexScreen() {
         onSelectConversation={handleSelect}
         nextCursor={nextCursor}
       />
-    </View>
+    </ScreenContainer>
   );
 }
 

--- a/apps/mobile-user/src/features/chat/ConversationList.test.tsx
+++ b/apps/mobile-user/src/features/chat/ConversationList.test.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ConversationList } from './ConversationList';
+
+vi.mock('react-native', () => {
+  type FlatListItem = {
+    id?: string;
+  };
+
+  type MockProps = {
+    children?: React.ReactNode;
+    onClick?: () => void;
+    onPress?: () => void;
+    testID?: string;
+  } & Record<string, unknown>;
+
+  const createComponent =
+    (tag: 'div' | 'button') =>
+    ({ children, onClick, onPress, testID, ...props }: MockProps) =>
+      React.createElement(
+        tag,
+        {
+          ...props,
+          'data-testid': testID,
+          onClick: onClick ?? onPress,
+        },
+        children as React.ReactNode
+      );
+
+  return {
+    ActivityIndicator: createComponent('div'),
+    FlatList: ({
+      data,
+      renderItem,
+      ListFooterComponent,
+    }: {
+      data: FlatListItem[];
+      renderItem: ({ item }: { item: FlatListItem }) => React.ReactNode;
+      ListFooterComponent?: React.ReactNode;
+    }) => (
+      <div>
+        {data.map((item) => renderItem({ item }))}
+        {ListFooterComponent}
+      </div>
+    ),
+    RefreshControl: createComponent('div'),
+    StyleSheet: { create: (styles: unknown) => styles },
+    View: createComponent('div'),
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('../../components/AppStateBlock', () => ({
+  AppStateBlock: ({
+    title,
+    description,
+    actionLabel,
+    onAction,
+  }: {
+    title: string;
+    description?: string;
+    actionLabel?: string;
+    onAction?: () => void;
+  }) => (
+    <div>
+      <span>{title}</span>
+      {description ? <span>{description}</span> : null}
+      {actionLabel ? <button onClick={onAction}>{actionLabel}</button> : null}
+    </div>
+  ),
+}));
+
+vi.mock('./ConversationRow', () => ({
+  ConversationRow: ({
+    conversation,
+    onPress,
+  }: {
+    conversation: { id: string };
+    onPress: () => void;
+  }) => <button onClick={onPress}>{conversation.id}</button>,
+}));
+
+describe('ConversationList', () => {
+  it('renders empty state copy when there are no conversations', () => {
+    render(
+      <ConversationList
+        items={[]}
+        loading={false}
+        error={null}
+        onRefresh={() => {}}
+        onLoadMore={() => {}}
+        onSelectConversation={() => {}}
+        nextCursor={null}
+      />
+    );
+
+    expect(screen.getByText('list.empty')).toBeTruthy();
+    expect(screen.getByText('list.emptyBody')).toBeTruthy();
+  });
+
+  it('renders error state with retry action', () => {
+    const onRefresh = vi.fn();
+
+    render(
+      <ConversationList
+        items={[]}
+        loading={false}
+        error={new Error('boom')}
+        onRefresh={onRefresh}
+        onLoadMore={() => {}}
+        onSelectConversation={() => {}}
+        nextCursor={null}
+      />
+    );
+
+    fireEvent.click(screen.getByText('list.retry'));
+    expect(onRefresh).toHaveBeenCalled();
+  });
+
+  it('renders rows and forwards selection', () => {
+    const onSelectConversation = vi.fn();
+
+    render(
+      <ConversationList
+        items={[
+          {
+            id: 'conv-1',
+            gymId: 'gym-1',
+            branchId: null,
+            type: 'support',
+            metadata: {},
+            createdAt: '2025-01-01T00:00:00Z',
+            updatedAt: '2025-01-01T00:00:00Z',
+          },
+        ]}
+        loading={false}
+        error={null}
+        onRefresh={() => {}}
+        onLoadMore={() => {}}
+        onSelectConversation={onSelectConversation}
+        nextCursor={null}
+      />
+    );
+
+    fireEvent.click(screen.getByText('conv-1'));
+    expect(onSelectConversation).toHaveBeenCalledWith('conv-1');
+  });
+});

--- a/apps/mobile-user/src/features/chat/ConversationList.tsx
+++ b/apps/mobile-user/src/features/chat/ConversationList.tsx
@@ -1,10 +1,9 @@
-/**
- * Conversation list with pull-to-refresh and unread badges.
- */
-import { View, Text, FlatList, RefreshControl, StyleSheet, ActivityIndicator } from 'react-native';
+import type { Conversation } from '@myclup/contracts/chat';
+import { View, FlatList, RefreshControl, StyleSheet, ActivityIndicator } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { ConversationRow } from './ConversationRow';
-import type { Conversation } from '@myclup/contracts/chat';
+import { AppStateBlock } from '../../components/AppStateBlock';
+import { appTheme } from '../../theme/appTheme';
 
 type ConversationWithUnread = Conversation & { unreadCount?: number };
 
@@ -31,17 +30,29 @@ export function ConversationList({
 
   if (error) {
     return (
-      <View style={styles.centered}>
-        <Text style={styles.errorText}>{error.message}</Text>
-      </View>
+      <AppStateBlock
+        icon="message-alert-outline"
+        title={t('list.error')}
+        description={t('list.errorBody')}
+        actionLabel={t('list.retry')}
+        onAction={onRefresh}
+      />
     );
   }
 
   if (!loading && items.length === 0) {
     return (
-      <View style={styles.centered}>
-        <Text style={styles.emptyText}>{t('list.empty')}</Text>
-      </View>
+      <AppStateBlock
+        icon="message-text-outline"
+        title={t('list.empty')}
+        description={t('list.emptyBody')}
+      />
+    );
+  }
+
+  if (loading && items.length === 0) {
+    return (
+      <AppStateBlock loading title={t('list.loadingTitle')} description={t('list.loadingBody')} />
     );
   }
 
@@ -62,7 +73,7 @@ export function ConversationList({
       ListFooterComponent={
         loading && items.length > 0 ? (
           <View style={styles.footer}>
-            <ActivityIndicator size="small" />
+            <ActivityIndicator size="small" color={appTheme.colors.primary} />
           </View>
         ) : null
       }
@@ -72,27 +83,13 @@ export function ConversationList({
 }
 
 const styles = StyleSheet.create({
-  centered: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 24,
-  },
-  emptyText: {
-    fontSize: 16,
-    color: '#666',
-    textAlign: 'center',
-  },
-  errorText: {
-    fontSize: 14,
-    color: '#c62828',
-    textAlign: 'center',
-  },
   listContent: {
+    flexGrow: 1,
+    gap: appTheme.spacing.sm,
     paddingBottom: 16,
   },
   footer: {
-    padding: 16,
+    paddingVertical: 16,
     alignItems: 'center',
   },
 });

--- a/apps/mobile-user/src/features/chat/ConversationRow.tsx
+++ b/apps/mobile-user/src/features/chat/ConversationRow.tsx
@@ -1,9 +1,9 @@
-/**
- * Conversation list row with optional unread badge.
- */
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { Pressable, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { Conversation } from '@myclup/contracts/chat';
+import { AppIcon } from '../../components/AppIcon';
+import { AppText } from '../../components/AppText';
+import { appTheme } from '../../theme/appTheme';
 
 type ConversationRowProps = {
   conversation: Conversation;
@@ -22,27 +22,58 @@ function getConversationTitleKey(conversation: Conversation): string {
   }
 }
 
+function getConversationIcon(conversation: Conversation) {
+  switch (conversation.type) {
+    case 'support':
+      return 'lifebuoy';
+    case 'instructor':
+      return 'account-star-outline';
+    default:
+      return 'chat-processing-outline';
+  }
+}
+
+function formatUpdatedAt(iso: string, locale: string) {
+  try {
+    return new Intl.DateTimeFormat(locale, {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+}
+
 export function ConversationRow({ conversation, unreadCount = 0, onPress }: ConversationRowProps) {
-  const { t } = useTranslation('chat');
-  const titleKey = getConversationTitleKey(conversation);
-  const title = t(titleKey);
+  const { t, i18n } = useTranslation('chat');
 
   return (
-    <TouchableOpacity style={styles.row} onPress={onPress} activeOpacity={0.7}>
-      <View style={styles.content}>
-        <Text style={styles.title} numberOfLines={1}>
-          {title}
-        </Text>
-        <Text style={styles.meta} numberOfLines={1}>
-          {conversation.type}
-        </Text>
+    <Pressable style={styles.row} onPress={onPress}>
+      <View style={styles.iconWrap}>
+        <AppIcon
+          name={getConversationIcon(conversation)}
+          size={20}
+          color={appTheme.colors.primary}
+        />
       </View>
-      {unreadCount > 0 && (
+      <View style={styles.content}>
+        <AppText style={styles.title} numberOfLines={1}>
+          {t(getConversationTitleKey(conversation))}
+        </AppText>
+        <AppText variant="caption" tone="muted" numberOfLines={1}>
+          {formatUpdatedAt(conversation.updatedAt, i18n.resolvedLanguage ?? 'en')}
+        </AppText>
+      </View>
+      {unreadCount > 0 ? (
         <View style={styles.badge}>
-          <Text style={styles.badgeText}>{unreadCount > 99 ? '99+' : unreadCount}</Text>
+          <AppText variant="caption" tone="inverse" style={styles.badgeText}>
+            {unreadCount > 99 ? '99+' : unreadCount}
+          </AppText>
         </View>
-      )}
-    </TouchableOpacity>
+      ) : null}
+    </Pressable>
   );
 }
 
@@ -50,37 +81,40 @@ const styles = StyleSheet.create({
   row: {
     flexDirection: 'row',
     alignItems: 'center',
-    padding: 16,
-    borderBottomWidth: 1,
-    borderBottomColor: '#eee',
-    backgroundColor: '#fff',
+    gap: appTheme.spacing.md,
+    paddingHorizontal: appTheme.spacing.md,
+    paddingVertical: appTheme.spacing.md,
+    borderWidth: 1,
+    borderColor: appTheme.colors.border,
+    borderRadius: appTheme.radii.lg,
+    backgroundColor: 'rgba(255,255,255,0.92)',
+  },
+  iconWrap: {
+    width: 42,
+    height: 42,
+    borderRadius: appTheme.radii.pill,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: appTheme.colors.primarySoft,
   },
   content: {
     flex: 1,
-    marginRight: 8,
   },
   title: {
     fontSize: 16,
-    fontWeight: '600',
-    color: '#111',
-  },
-  meta: {
-    fontSize: 13,
-    color: '#666',
-    marginTop: 2,
+    lineHeight: 22,
+    fontWeight: '700',
   },
   badge: {
-    minWidth: 22,
-    height: 22,
-    borderRadius: 11,
-    backgroundColor: '#e53935',
+    minWidth: 26,
+    height: 26,
+    borderRadius: appTheme.radii.pill,
+    backgroundColor: appTheme.colors.primary,
     justifyContent: 'center',
     alignItems: 'center',
-    paddingHorizontal: 6,
+    paddingHorizontal: 8,
   },
   badgeText: {
-    fontSize: 12,
-    fontWeight: '600',
-    color: '#fff',
+    fontWeight: '700',
   },
 });

--- a/apps/mobile-user/src/features/chat/MessageBubble.tsx
+++ b/apps/mobile-user/src/features/chat/MessageBubble.tsx
@@ -1,9 +1,8 @@
-/**
- * Message bubble with read receipt indicator.
- */
-import { View, Text, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { Message } from '@myclup/contracts/chat';
+import { AppText } from '../../components/AppText';
+import { appTheme } from '../../theme/appTheme';
 
 type MessageBubbleProps = {
   message: Message;
@@ -11,28 +10,36 @@ type MessageBubbleProps = {
   showReadReceipt?: boolean;
 };
 
-function formatTime(iso: string): string {
+function formatTime(iso: string, locale: string): string {
   try {
-    const d = new Date(iso);
-    return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+    const date = new Date(iso);
+    return date.toLocaleTimeString(locale, { hour: '2-digit', minute: '2-digit' });
   } catch {
     return '';
   }
 }
 
 export function MessageBubble({ message, isOwn, showReadReceipt = false }: MessageBubbleProps) {
-  const { t } = useTranslation('chat');
-  const time = formatTime(message.createdAt);
+  const { t, i18n } = useTranslation('chat');
 
   return (
     <View style={[styles.wrapper, isOwn ? styles.own : styles.other]}>
       <View style={[styles.bubble, isOwn ? styles.bubbleOwn : styles.bubbleOther]}>
-        <Text style={[styles.content, isOwn ? styles.contentOwn : styles.contentOther]}>
+        <AppText style={[styles.content, isOwn ? styles.contentOwn : styles.contentOther]}>
           {message.content}
-        </Text>
+        </AppText>
         <View style={styles.footer}>
-          <Text style={[styles.time, isOwn ? styles.timeOwn : styles.timeOther]}>{time}</Text>
-          {isOwn && showReadReceipt && <Text style={styles.receipt}>{t('status.read')}</Text>}
+          <AppText
+            variant="caption"
+            style={[styles.time, isOwn ? styles.timeOwn : styles.timeOther]}
+          >
+            {formatTime(message.createdAt, i18n.resolvedLanguage ?? 'en')}
+          </AppText>
+          {isOwn && showReadReceipt ? (
+            <AppText variant="caption" style={styles.receipt}>
+              {t('status.read')}
+            </AppText>
+          ) : null}
         </View>
       </View>
     </View>
@@ -42,7 +49,6 @@ export function MessageBubble({ message, isOwn, showReadReceipt = false }: Messa
 const styles = StyleSheet.create({
   wrapper: {
     alignSelf: 'stretch',
-    alignItems: 'flex-start',
     marginHorizontal: 16,
     marginVertical: 4,
   },
@@ -53,27 +59,30 @@ const styles = StyleSheet.create({
     alignItems: 'flex-start',
   },
   bubble: {
-    maxWidth: '80%',
-    borderRadius: 16,
+    maxWidth: '82%',
+    borderRadius: appTheme.radii.md,
     paddingHorizontal: 14,
     paddingVertical: 10,
+    borderWidth: 1,
   },
   bubbleOwn: {
-    backgroundColor: '#2196f3',
+    backgroundColor: appTheme.colors.secondary,
+    borderColor: appTheme.colors.secondary,
     borderBottomRightRadius: 4,
   },
   bubbleOther: {
-    backgroundColor: '#f0f0f0',
+    backgroundColor: 'rgba(255,255,255,0.92)',
+    borderColor: appTheme.colors.border,
     borderBottomLeftRadius: 4,
   },
   content: {
     fontSize: 15,
   },
   contentOwn: {
-    color: '#fff',
+    color: appTheme.colors.primaryText,
   },
   contentOther: {
-    color: '#111',
+    color: appTheme.colors.text,
   },
   footer: {
     flexDirection: 'row',
@@ -85,13 +94,12 @@ const styles = StyleSheet.create({
     fontSize: 11,
   },
   timeOwn: {
-    color: 'rgba(255,255,255,0.8)',
+    color: 'rgba(255,255,255,0.82)',
   },
   timeOther: {
-    color: '#888',
+    color: appTheme.colors.textSoft,
   },
   receipt: {
-    fontSize: 10,
-    color: 'rgba(255,255,255,0.8)',
+    color: 'rgba(255,255,255,0.82)',
   },
 });

--- a/apps/mobile-user/src/features/chat/MessageInput.tsx
+++ b/apps/mobile-user/src/features/chat/MessageInput.tsx
@@ -1,9 +1,9 @@
-/**
- * Message input with send button.
- */
 import { useState, useCallback } from 'react';
-import { View, TextInput, TouchableOpacity, Text, StyleSheet } from 'react-native';
+import { View, TextInput, Pressable, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
+import { AppIcon } from '../../components/AppIcon';
+import { AppText } from '../../components/AppText';
+import { appTheme } from '../../theme/appTheme';
 
 type MessageInputProps = {
   onSend: (content: string) => void | Promise<void>;
@@ -18,7 +18,10 @@ export function MessageInput({ onSend, disabled = false, onTypingChange }: Messa
 
   const handleSend = useCallback(async () => {
     const trimmed = text.trim();
-    if (!trimmed || disabled) return;
+    if (!trimmed || disabled) {
+      return;
+    }
+
     setText('');
     onTypingChange?.(false);
     setSending(true);
@@ -34,7 +37,7 @@ export function MessageInput({ onSend, disabled = false, onTypingChange }: Messa
       <TextInput
         style={styles.input}
         placeholder={t('input.placeholder')}
-        placeholderTextColor="#999"
+        placeholderTextColor={appTheme.colors.textSoft}
         value={text}
         onChangeText={setText}
         onSubmitEditing={handleSend}
@@ -45,16 +48,25 @@ export function MessageInput({ onSend, disabled = false, onTypingChange }: Messa
         onFocus={() => onTypingChange?.(true)}
         onBlur={() => onTypingChange?.(false)}
         onSelectionChange={() => {
-          if (text.length > 0) onTypingChange?.(true);
+          if (text.length > 0) {
+            onTypingChange?.(true);
+          }
         }}
       />
-      <TouchableOpacity
+      <Pressable
         style={[styles.sendButton, (!text.trim() || disabled || sending) && styles.sendDisabled]}
         onPress={handleSend}
         disabled={!text.trim() || disabled || sending}
       >
-        <Text style={styles.sendText}>{sending ? t('status.sending') : t('input.send')}</Text>
-      </TouchableOpacity>
+        <AppIcon
+          name={sending ? 'progress-clock' : 'send'}
+          size={18}
+          color={appTheme.colors.primaryText}
+        />
+        <AppText tone="inverse" style={styles.sendText}>
+          {sending ? t('status.sending') : t('input.send')}
+        </AppText>
+      </Pressable>
     </View>
   );
 }
@@ -65,8 +77,9 @@ const styles = StyleSheet.create({
     alignItems: 'flex-end',
     padding: 12,
     borderTopWidth: 1,
-    borderTopColor: '#eee',
-    backgroundColor: '#fff',
+    borderTopColor: appTheme.colors.border,
+    backgroundColor: 'rgba(255,255,255,0.96)',
+    borderRadius: appTheme.radii.xl,
     gap: 8,
   },
   input: {
@@ -75,24 +88,27 @@ const styles = StyleSheet.create({
     maxHeight: 100,
     paddingHorizontal: 14,
     paddingVertical: 10,
-    backgroundColor: '#f5f5f5',
+    backgroundColor: appTheme.colors.surfaceMuted,
     borderRadius: 20,
     fontSize: 16,
-    color: '#111',
+    color: appTheme.colors.text,
+    fontFamily: appTheme.fontFamily,
   },
   sendButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
     paddingHorizontal: 16,
     paddingVertical: 10,
-    backgroundColor: '#2196f3',
+    backgroundColor: appTheme.colors.primary,
     borderRadius: 20,
     justifyContent: 'center',
     minHeight: 40,
   },
   sendDisabled: {
-    backgroundColor: '#b0bec5',
+    backgroundColor: '#9fb1bf',
   },
   sendText: {
-    color: '#fff',
     fontWeight: '600',
     fontSize: 15,
   },

--- a/apps/mobile-user/src/features/chat/MessageThread.test.tsx
+++ b/apps/mobile-user/src/features/chat/MessageThread.test.tsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { MessageThread } from './MessageThread';
+
+vi.mock('react-native', () => {
+  type FlatListItem = {
+    id?: string;
+  };
+
+  type MockProps = {
+    children?: React.ReactNode;
+    onClick?: () => void;
+    onPress?: () => void;
+    testID?: string;
+    value?: string;
+  } & Record<string, unknown>;
+
+  const createComponent =
+    (tag: 'div' | 'button') =>
+    ({ children, onClick, onPress, testID, value, ...props }: MockProps) =>
+      React.createElement(
+        tag,
+        {
+          ...props,
+          'data-testid': testID,
+          onClick: onClick ?? onPress,
+          value,
+        },
+        children as React.ReactNode
+      );
+
+  return {
+    FlatList: ({
+      data,
+      renderItem,
+      ListEmptyComponent,
+    }: {
+      data: FlatListItem[];
+      renderItem: ({ item }: { item: FlatListItem }) => React.ReactNode;
+      ListEmptyComponent?: React.ReactNode;
+    }) => (
+      <div>{data.length === 0 ? ListEmptyComponent : data.map((item) => renderItem({ item }))}</div>
+    ),
+    KeyboardAvoidingView: createComponent('div'),
+    Platform: { OS: 'web' },
+    Pressable: createComponent('button'),
+    StyleSheet: { create: (styles: unknown) => styles },
+    TextInput: ({
+      onChangeText,
+      value,
+      placeholder,
+      ...props
+    }: {
+      onChangeText?: (value: string) => void;
+      value?: string;
+      placeholder?: string;
+    } & Record<string, unknown>) =>
+      React.createElement('textarea', {
+        ...props,
+        placeholder,
+        value,
+        onChange: (event: { target: { value: string } }) => onChangeText?.(event.target.value),
+      }),
+    View: createComponent('div'),
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { resolvedLanguage: 'en' },
+  }),
+}));
+
+vi.mock('@myclup/ui-native', () => ({
+  Card: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('../../components/AppStateBlock', () => ({
+  AppStateBlock: ({ title, description }: { title: string; description?: string }) => (
+    <div>
+      <span>{title}</span>
+      {description ? <span>{description}</span> : null}
+    </div>
+  ),
+}));
+
+vi.mock('../../components/AppText', () => ({
+  AppText: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock('../../components/AppIcon', () => ({
+  AppIcon: ({ name }: { name: string }) => <span>{name}</span>,
+}));
+
+describe('MessageThread', () => {
+  it('renders localized empty state when there are no messages', () => {
+    render(
+      <MessageThread
+        conversationId="conv-1"
+        messages={[]}
+        currentUserId="user-1"
+        loading={false}
+        error={null}
+        onSendMessage={async () => {}}
+        typingLabel={null}
+        onTypingChange={() => {}}
+      />
+    );
+
+    expect(screen.getByText('thread.emptyTitle')).toBeTruthy();
+    expect(screen.getByText('thread.emptyBody')).toBeTruthy();
+  });
+
+  it('renders generic error state copy instead of raw error details', () => {
+    render(
+      <MessageThread
+        conversationId="conv-1"
+        messages={[]}
+        currentUserId="user-1"
+        loading={false}
+        error={new Error('raw backend message')}
+        onSendMessage={async () => {}}
+        typingLabel={null}
+        onTypingChange={() => {}}
+      />
+    );
+
+    expect(screen.getByText('thread.errorTitle')).toBeTruthy();
+    expect(screen.queryByText('raw backend message')).toBeNull();
+  });
+
+  it('forwards outgoing messages through the composer', () => {
+    const onSendMessage = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <MessageThread
+        conversationId="conv-1"
+        messages={[
+          {
+            id: 'msg-1',
+            conversationId: 'conv-1',
+            senderId: 'user-2',
+            content: 'Hello',
+            dedupeKey: null,
+            createdAt: '2025-01-01T10:00:00Z',
+          },
+        ]}
+        currentUserId="user-1"
+        loading={false}
+        error={null}
+        onSendMessage={onSendMessage}
+        typingLabel="label.typingSomeone"
+        onTypingChange={() => {}}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('input.placeholder'), {
+      target: { value: 'Hi there' },
+    });
+    fireEvent.click(screen.getByText('input.send'));
+
+    expect(onSendMessage).toHaveBeenCalledWith('Hi there');
+    expect(screen.getByText('label.typingSomeone')).toBeTruthy();
+  });
+});

--- a/apps/mobile-user/src/features/chat/MessageThread.tsx
+++ b/apps/mobile-user/src/features/chat/MessageThread.tsx
@@ -1,20 +1,13 @@
-/**
- * Message thread with optimistic send, Realtime updates, typing indicator.
- */
-import { useCallback, useRef, useEffect } from 'react';
-import {
-  View,
-  Text,
-  FlatList,
-  StyleSheet,
-  ActivityIndicator,
-  KeyboardAvoidingView,
-  Platform,
-} from 'react-native';
+import { useCallback, useEffect, useRef } from 'react';
+import { View, FlatList, StyleSheet, KeyboardAvoidingView, Platform } from 'react-native';
 import { useTranslation } from 'react-i18next';
+import { Card } from '@myclup/ui-native';
 import type { Message } from '@myclup/contracts/chat';
 import { MessageBubble } from './MessageBubble';
 import { MessageInput } from './MessageInput';
+import { AppStateBlock } from '../../components/AppStateBlock';
+import { AppText } from '../../components/AppText';
+import { appTheme } from '../../theme/appTheme';
 
 type MessageThreadProps = {
   conversationId?: string;
@@ -23,7 +16,7 @@ type MessageThreadProps = {
   loading: boolean;
   error: Error | null;
   onSendMessage: (content: string) => Promise<void>;
-  typingNames: string[];
+  typingLabel: string | null;
   onTypingChange: (typing: boolean) => void;
 };
 
@@ -33,7 +26,7 @@ export function MessageThread({
   loading,
   error,
   onSendMessage,
-  typingNames,
+  typingLabel,
   onTypingChange,
 }: MessageThreadProps) {
   const { t } = useTranslation('chat');
@@ -54,9 +47,11 @@ export function MessageThread({
 
   if (error) {
     return (
-      <View style={styles.centered}>
-        <Text style={styles.errorText}>{error.message}</Text>
-      </View>
+      <AppStateBlock
+        icon="message-alert-outline"
+        title={t('thread.errorTitle')}
+        description={t('thread.errorBody')}
+      />
     );
   }
 
@@ -67,37 +62,47 @@ export function MessageThread({
       keyboardVerticalOffset={90}
     >
       {loading && messages.length === 0 ? (
-        <View style={styles.centered}>
-          <ActivityIndicator size="large" />
-        </View>
-      ) : (
-        <FlatList
-          ref={flatListRef}
-          data={messages}
-          keyExtractor={(item) => item.id}
-          renderItem={({ item }) => (
-            <MessageBubble
-              message={item}
-              isOwn={item.senderId === currentUserId}
-              showReadReceipt={item.senderId === currentUserId}
-            />
-          )}
-          ListEmptyComponent={
-            <View style={styles.empty}>
-              <Text style={styles.emptyText}>{t('empty.noMessages')}</Text>
-            </View>
-          }
-          contentContainerStyle={[
-            styles.listContent,
-            messages.length === 0 && styles.listContentEmpty,
-          ]}
+        <AppStateBlock
+          loading
+          title={t('thread.loadingTitle')}
+          description={t('thread.loadingBody')}
         />
+      ) : (
+        <Card style={styles.threadCard}>
+          <FlatList
+            ref={flatListRef}
+            data={messages}
+            keyExtractor={(item) => item.id}
+            renderItem={({ item }) => (
+              <MessageBubble
+                message={item}
+                isOwn={item.senderId === currentUserId}
+                showReadReceipt={item.senderId === currentUserId}
+              />
+            )}
+            ListEmptyComponent={
+              <View style={styles.empty}>
+                <AppStateBlock
+                  icon="message-text-outline"
+                  title={t('thread.emptyTitle')}
+                  description={t('thread.emptyBody')}
+                />
+              </View>
+            }
+            contentContainerStyle={[
+              styles.listContent,
+              messages.length === 0 && styles.listContentEmpty,
+            ]}
+          />
+        </Card>
       )}
-      {typingNames.length > 0 && (
+      {typingLabel ? (
         <View style={styles.typingBar}>
-          <Text style={styles.typingText}>{t('label.typing', { name: typingNames[0] })}</Text>
+          <AppText variant="caption" tone="soft" style={styles.typingText}>
+            {typingLabel}
+          </AppText>
         </View>
-      )}
+      ) : null}
       <MessageInput onSend={handleSend} onTypingChange={onTypingChange} />
     </KeyboardAvoidingView>
   );
@@ -106,41 +111,32 @@ export function MessageThread({
 const styles = StyleSheet.create({
   flex: {
     flex: 1,
+    gap: appTheme.spacing.sm,
   },
-  centered: {
+  threadCard: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
+    paddingHorizontal: 0,
+    paddingVertical: appTheme.spacing.sm,
+    backgroundColor: 'rgba(255,255,255,0.94)',
   },
   empty: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingVertical: 48,
-  },
-  emptyText: {
-    fontSize: 16,
-    color: '#666',
-  },
-  errorText: {
-    fontSize: 14,
-    color: '#c62828',
+    paddingHorizontal: appTheme.spacing.md,
+    paddingVertical: appTheme.spacing.xl,
   },
   listContent: {
-    paddingVertical: 16,
+    paddingVertical: appTheme.spacing.sm,
     flexGrow: 1,
   },
   listContentEmpty: {
     justifyContent: 'center',
   },
   typingBar: {
-    paddingHorizontal: 16,
+    paddingHorizontal: appTheme.spacing.md,
     paddingVertical: 6,
-    backgroundColor: '#f5f5f5',
+    backgroundColor: 'rgba(255,255,255,0.9)',
+    borderRadius: appTheme.radii.md,
   },
   typingText: {
-    fontSize: 13,
-    color: '#666',
     fontStyle: 'italic',
   },
 });

--- a/packages/i18n/src/__tests__/chat-keys.test.ts
+++ b/packages/i18n/src/__tests__/chat-keys.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import chatEn from '../namespaces/chat/en.json';
+import chatTr from '../namespaces/chat/tr.json';
+
+function flattenKeys(value: Record<string, unknown>, prefix = ''): string[] {
+  return Object.entries(value).flatMap(([key, nestedValue]) => {
+    const currentKey = prefix ? `${prefix}.${key}` : key;
+    if (nestedValue && typeof nestedValue === 'object' && !Array.isArray(nestedValue)) {
+      return flattenKeys(nestedValue as Record<string, unknown>, currentKey);
+    }
+
+    return [currentKey];
+  });
+}
+
+describe('chat locale keys', () => {
+  it('keeps chat copy in parity across locales', () => {
+    expect(flattenKeys(chatTr as Record<string, unknown>)).toEqual(
+      flattenKeys(chatEn as Record<string, unknown>)
+    );
+  });
+});

--- a/packages/i18n/src/namespaces/chat/en.json
+++ b/packages/i18n/src/namespaces/chat/en.json
@@ -4,9 +4,17 @@
   },
   "list": {
     "title": "Chat",
+    "subtitle": "Stay close to your gym support and instructors in one place.",
     "loading": "Loading conversations...",
+    "loadingTitle": "Loading your conversations",
+    "loadingBody": "Fetching the latest member chat threads.",
     "error": "Failed to load conversations",
+    "errorTitle": "Chat list unavailable",
+    "errorBody": "We could not load your conversations right now. Try again.",
     "empty": "No conversations yet",
+    "emptyTitle": "No conversations yet",
+    "emptyBody": "Your support and coaching conversations will appear here.",
+    "retry": "Try again",
     "filterAll": "All",
     "filterUnread": "Unread",
     "filterAssigned": "Assigned to me",
@@ -31,7 +39,16 @@
   "conversation": {
     "withGym": "Gym support",
     "withInstructor": "Instructor",
-    "direct": "Direct message"
+    "direct": "Direct message",
+    "group": "Group chat",
+    "broadcast": "Announcements",
+    "type": {
+      "support": "Support thread",
+      "instructor": "Instructor thread",
+      "direct": "Direct conversation",
+      "group": "Group conversation",
+      "broadcast": "Broadcast thread"
+    }
   },
   "input": {
     "placeholder": "Type a message...",
@@ -47,6 +64,17 @@
   },
   "empty": {
     "noMessages": "No messages yet. Start the conversation!"
+  },
+  "thread": {
+    "title": "Conversation",
+    "subtitle": "Messages stay synced with your gym support flow.",
+    "loadingTitle": "Loading conversation",
+    "loadingBody": "Pulling the latest messages and read state.",
+    "errorTitle": "Conversation unavailable",
+    "errorBody": "We could not load this chat right now.",
+    "emptyTitle": "No messages yet",
+    "emptyBody": "Send the first message to start this conversation.",
+    "composerHint": "Messages send through the existing realtime chat channel."
   },
   "status": {
     "sending": "Sending...",

--- a/packages/i18n/src/namespaces/chat/tr.json
+++ b/packages/i18n/src/namespaces/chat/tr.json
@@ -4,9 +4,17 @@
   },
   "list": {
     "title": "Sohbet",
+    "subtitle": "Salon destegi ve egitmen mesajlarini tek yerde takip edin.",
     "loading": "Konuşmalar yükleniyor...",
+    "loadingTitle": "Konusmalariniz yukleniyor",
+    "loadingBody": "Uye sohbetleri getiriliyor.",
     "error": "Konuşmalar yüklenemedi",
+    "errorTitle": "Sohbet listesi kullanilamiyor",
+    "errorBody": "Konusmalar su anda yuklenemedi. Tekrar deneyin.",
     "empty": "Henüz konuşma yok",
+    "emptyTitle": "Henuz konusma yok",
+    "emptyBody": "Destek ve kocluk konusmalariniz burada gorunecek.",
+    "retry": "Tekrar dene",
     "filterAll": "Tümü",
     "filterUnread": "Okunmamış",
     "filterAssigned": "Bana atanmış",
@@ -31,7 +39,16 @@
   "conversation": {
     "withGym": "Salon desteği",
     "withInstructor": "Eğitmen",
-    "direct": "Doğrudan mesaj"
+    "direct": "Doğrudan mesaj",
+    "group": "Grup sohbeti",
+    "broadcast": "Duyurular",
+    "type": {
+      "support": "Destek sohbeti",
+      "instructor": "Egitmen sohbeti",
+      "direct": "Dogrudan konusma",
+      "group": "Grup konusmasi",
+      "broadcast": "Duyuru akisi"
+    }
   },
   "input": {
     "placeholder": "Mesaj yazın...",
@@ -47,6 +64,17 @@
   },
   "empty": {
     "noMessages": "Henüz mesaj yok. Konuşmayı başlatın!"
+  },
+  "thread": {
+    "title": "Konusma",
+    "subtitle": "Mesajlariniz salon destek akisiyla senkron kalir.",
+    "loadingTitle": "Konusma yukleniyor",
+    "loadingBody": "Son mesajlar ve okunma durumu getiriliyor.",
+    "errorTitle": "Konusma kullanilamiyor",
+    "errorBody": "Bu sohbet su anda yuklenemedi.",
+    "emptyTitle": "Henuz mesaj yok",
+    "emptyBody": "Bu konusmayi baslatmak icin ilk mesaji gonderin.",
+    "composerHint": "Mesajlar mevcut realtime sohbet kanali uzerinden gonderilir."
   },
   "status": {
     "sending": "Gönderiliyor...",


### PR DESCRIPTION
Closes #138

Epic: #30

Summary:
- align the mobile member chat list and thread surfaces with shared shell typography, iconography, and state blocks
- remove hardcoded chat UI copy in favor of translation-driven loading, empty, error, and typing states
- add chat component coverage and locale-parity checks for the new UI copy

Acceptance Criteria:
- [x] Chat list screen visually matches the shared member app shell and typography system
- [x] Chat thread screen uses shared UI/state patterns and removes hardcoded member-facing strings
- [x] Loading, empty, and error states use shared components and translation-driven copy
- [x] Existing conversation list, thread loading, optimistic send, and realtime behavior continue to work
- [x] New or changed chat copy has locale parity coverage
- [x] Mobile chat remains usable on common phone widths without layout regressions

Validation:
- `pnpm --filter @myclup/mobile-user lint`
- `pnpm --filter @myclup/mobile-user typecheck`
- `pnpm --filter @myclup/mobile-user test`
- `pnpm --filter @myclup/i18n test`
