### PR TITLE
feat: add booking reporting foundations

### DIFF
--- a/packages/supabase/src/audit/FLOWS.md
+++ b/packages/supabase/src/audit/FLOWS.md
@@ -28,6 +28,15 @@ Per `.cursor/rules/chat-first-realtime-safety.mdc`, staff-assigned chat reassign
 
 Full moderation UI and platform admin oversight views are out of scope for Epic 17; these hooks define integration points when those features are built.
 
+## Booking Reporting and Follow-Up Foundations
+
+Derived booking reporting and follow-up outputs are allowed to stay read-only and shared until a delivery transport or UI surface needs explicit persistence.
+
+- Capacity, fill-rate, and attendance summaries should be derived from the canonical booking/session records, not recomputed separately in each surface.
+- Reminder, missed-class follow-up, and rebook suggestion outputs should be generated from the canonical booking lifecycle and session inventory.
+- When platform admins or support staff access these derived booking outputs across tenants, callers should reuse the existing `cross_tenant_support` audit pattern.
+- If a future implementation persists or dispatches a reminder/follow-up action, that write path must add an explicit booking-related audit event at the point of dispatch.
+
 ## Call Pattern
 
 For flows that alter state:

--- a/packages/supabase/src/bookings/foundations.test.ts
+++ b/packages/supabase/src/bookings/foundations.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import type { BookingRecord, BookingSession } from '@myclup/contracts/bookings';
+import { buildBookingCapacityReports, buildBookingFollowUpEvents } from './foundations';
+
+const sessionA: BookingSession = {
+  id: '550e8400-e29b-41d4-a716-446655440010',
+  gymId: '550e8400-e29b-41d4-a716-446655440000',
+  branchId: null,
+  kind: 'class',
+  status: 'scheduled',
+  title: 'Morning Class',
+  startsAt: '2025-03-19T12:00:00.000Z',
+  endsAt: '2025-03-19T13:00:00.000Z',
+  timezone: 'Europe/Istanbul',
+  instructor: {
+    userId: '550e8400-e29b-41d4-a716-446655440001',
+    displayName: 'Coach Ada',
+  },
+  capacity: 10,
+  bookedCount: 6,
+  waitlistCount: 2,
+  availableSpots: 4,
+  locationLabel: null,
+  createdAt: '2025-03-18T12:00:00.000Z',
+  updatedAt: '2025-03-18T12:00:00.000Z',
+};
+
+const sessionB: BookingSession = {
+  ...sessionA,
+  id: '550e8400-e29b-41d4-a716-446655440011',
+  startsAt: '2025-03-20T12:00:00.000Z',
+  endsAt: '2025-03-20T13:00:00.000Z',
+};
+
+const sessionC: BookingSession = {
+  ...sessionA,
+  id: '550e8400-e29b-41d4-a716-446655440012',
+  title: 'Evening PT',
+  kind: 'personal_training',
+  startsAt: '2025-03-20T18:00:00.000Z',
+  endsAt: '2025-03-20T19:00:00.000Z',
+};
+
+const bookingBase: BookingRecord = {
+  id: '550e8400-e29b-41d4-a716-446655440020',
+  sessionId: sessionA.id,
+  memberId: '550e8400-e29b-41d4-a716-446655440030',
+  gymId: sessionA.gymId,
+  branchId: null,
+  status: 'booked',
+  attendanceStatus: 'pending',
+  bookedAt: '2025-03-18T13:00:00.000Z',
+  cancelledAt: null,
+  waitlistedAt: null,
+  checkInAt: null,
+  waitlistPosition: null,
+  notes: null,
+  createdAt: '2025-03-18T13:00:00.000Z',
+  updatedAt: '2025-03-18T13:00:00.000Z',
+};
+
+describe('booking foundations', () => {
+  it('builds capacity and attendance report summaries from canonical records', () => {
+    const reports = buildBookingCapacityReports(
+      [sessionA],
+      [
+        bookingBase,
+        {
+          ...bookingBase,
+          id: '550e8400-e29b-41d4-a716-446655440021',
+          attendanceStatus: 'checked_in',
+        },
+        {
+          ...bookingBase,
+          id: '550e8400-e29b-41d4-a716-446655440022',
+          status: 'cancelled',
+          attendanceStatus: 'cancelled',
+          cancelledAt: '2025-03-19T10:00:00.000Z',
+        },
+        {
+          ...bookingBase,
+          id: '550e8400-e29b-41d4-a716-446655440023',
+          attendanceStatus: 'missed',
+          status: 'no_show',
+        },
+      ],
+      '2025-03-19T09:00:00.000Z'
+    );
+
+    expect(reports).toHaveLength(1);
+    expect(reports[0]).toMatchObject({
+      sessionId: sessionA.id,
+      fillRate: 0.6,
+      attendedCount: 1,
+      missedCount: 1,
+      cancelledCount: 1,
+      upcomingReminderCount: 1,
+      rebookEligibleCount: 2,
+    });
+  });
+
+  it('emits reminder, missed follow-up, and rebook events from shared booking data', () => {
+    const events = buildBookingFollowUpEvents({
+      sessions: [sessionA, sessionB, sessionC],
+      bookings: [
+        {
+          ...bookingBase,
+          id: '550e8400-e29b-41d4-a716-446655440026',
+          sessionId: sessionB.id,
+        },
+        {
+          ...bookingBase,
+          id: '550e8400-e29b-41d4-a716-446655440024',
+          attendanceStatus: 'missed',
+          status: 'booked',
+        },
+        {
+          ...bookingBase,
+          id: '550e8400-e29b-41d4-a716-446655440025',
+          attendanceStatus: 'cancelled',
+          status: 'cancelled',
+          cancelledAt: '2025-03-19T09:30:00.000Z',
+        },
+      ],
+      now: '2025-03-19T14:00:00.000Z',
+    });
+
+    expect(events.map((event) => event.type)).toEqual([
+      'upcoming_session_reminder',
+      'missed_session_follow_up',
+      'rebook_invitation',
+      'rebook_invitation',
+    ]);
+    expect(events[1].suggestedSessionIds).toContain(sessionB.id);
+    expect(events[2].suggestedSessionIds).toContain(sessionB.id);
+  });
+});

--- a/packages/supabase/src/bookings/foundations.ts
+++ b/packages/supabase/src/bookings/foundations.ts
@@ -1,0 +1,244 @@
+import type { BookingRecord, BookingSession } from '@myclup/contracts/bookings';
+
+export type BookingFollowUpEventType =
+  | 'upcoming_session_reminder'
+  | 'missed_session_follow_up'
+  | 'rebook_invitation';
+
+export interface BookingCapacityReport {
+  sessionId: string;
+  gymId: string;
+  branchId: string | null;
+  title: string;
+  startsAt: string;
+  endsAt: string;
+  capacity: number;
+  bookedCount: number;
+  waitlistCount: number;
+  fillRate: number;
+  attendedCount: number;
+  missedCount: number;
+  cancelledCount: number;
+  attendanceRate: number;
+  upcomingReminderCount: number;
+  rebookEligibleCount: number;
+}
+
+export interface BookingFollowUpEvent {
+  type: BookingFollowUpEventType;
+  key: string;
+  gymId: string;
+  branchId: string | null;
+  memberId: string;
+  sessionId: string;
+  bookingId: string;
+  sessionTitle: string;
+  scheduledFor: string;
+  sessionStartsAt: string;
+  attendanceStatus: BookingRecord['attendanceStatus'];
+  bookingStatus: BookingRecord['status'];
+  suggestedSessionIds: string[];
+}
+
+export interface BookingFollowUpBuilderInput {
+  bookings: BookingRecord[];
+  sessions: BookingSession[];
+  now?: string;
+  reminderLeadHours?: number;
+  reminderLookaheadHours?: number;
+  followUpLookbackHours?: number;
+  suggestionLimit?: number;
+}
+
+function toEpoch(value: string) {
+  return new Date(value).getTime();
+}
+
+function clampRate(value: number) {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+function compareSessionSimilarity(source: BookingSession, candidate: BookingSession) {
+  let score = 0;
+  if (source.kind === candidate.kind) score += 4;
+  if (source.instructor?.userId && source.instructor.userId === candidate.instructor?.userId) {
+    score += 3;
+  }
+  if (source.title === candidate.title) score += 2;
+  if (source.branchId && source.branchId === candidate.branchId) score += 1;
+  return score;
+}
+
+function getSuggestedSessions(
+  session: BookingSession,
+  sessions: BookingSession[],
+  suggestionLimit: number
+) {
+  return sessions
+    .filter(
+      (candidate) =>
+        candidate.id !== session.id &&
+        candidate.gymId === session.gymId &&
+        candidate.status === 'scheduled' &&
+        toEpoch(candidate.startsAt) > toEpoch(session.startsAt)
+    )
+    .sort((left, right) => {
+      const scoreDiff =
+        compareSessionSimilarity(session, right) - compareSessionSimilarity(session, left);
+      if (scoreDiff !== 0) return scoreDiff;
+      return toEpoch(left.startsAt) - toEpoch(right.startsAt);
+    })
+    .slice(0, suggestionLimit)
+    .map((candidate) => candidate.id);
+}
+
+export function buildBookingCapacityReports(
+  sessions: BookingSession[],
+  bookings: BookingRecord[],
+  now = new Date().toISOString()
+): BookingCapacityReport[] {
+  return sessions.map((session) => {
+    const sessionBookings = bookings.filter((booking) => booking.sessionId === session.id);
+    const attendedCount = sessionBookings.filter(
+      (booking) =>
+        booking.attendanceStatus === 'checked_in' || booking.attendanceStatus === 'completed'
+    ).length;
+    const missedCount = sessionBookings.filter(
+      (booking) => booking.attendanceStatus === 'missed' || booking.status === 'no_show'
+    ).length;
+    const cancelledCount = sessionBookings.filter(
+      (booking) => booking.status === 'cancelled'
+    ).length;
+    const upcomingReminderCount = sessionBookings.filter(
+      (booking) =>
+        booking.status === 'booked' &&
+        booking.attendanceStatus === 'pending' &&
+        toEpoch(session.startsAt) > toEpoch(now)
+    ).length;
+    const rebookEligibleCount = sessionBookings.filter(
+      (booking) =>
+        booking.status === 'cancelled' ||
+        booking.attendanceStatus === 'missed' ||
+        booking.status === 'no_show'
+    ).length;
+    const activeAttendanceBase = Math.max(session.bookedCount - cancelledCount, 0);
+
+    return {
+      sessionId: session.id,
+      gymId: session.gymId,
+      branchId: session.branchId,
+      title: session.title,
+      startsAt: session.startsAt,
+      endsAt: session.endsAt,
+      capacity: session.capacity,
+      bookedCount: session.bookedCount,
+      waitlistCount: session.waitlistCount,
+      fillRate: clampRate(session.capacity === 0 ? 0 : session.bookedCount / session.capacity),
+      attendedCount,
+      missedCount,
+      cancelledCount,
+      attendanceRate: clampRate(
+        activeAttendanceBase === 0 ? 0 : attendedCount / activeAttendanceBase
+      ),
+      upcomingReminderCount,
+      rebookEligibleCount,
+    };
+  });
+}
+
+export function buildBookingFollowUpEvents({
+  bookings,
+  sessions,
+  now = new Date().toISOString(),
+  reminderLeadHours = 2,
+  reminderLookaheadHours = 24,
+  followUpLookbackHours = 72,
+  suggestionLimit = 3,
+}: BookingFollowUpBuilderInput): BookingFollowUpEvent[] {
+  const sessionById = new Map(sessions.map((session) => [session.id, session]));
+  const nowEpoch = toEpoch(now);
+  const reminderLeadMs = reminderLeadHours * 60 * 60 * 1000;
+  const reminderLookaheadMs = reminderLookaheadHours * 60 * 60 * 1000;
+  const followUpLookbackMs = followUpLookbackHours * 60 * 60 * 1000;
+
+  return bookings.flatMap((booking) => {
+    const session = sessionById.get(booking.sessionId);
+    if (!session) return [];
+
+    const sessionStartsAt = toEpoch(session.startsAt);
+    const sessionEndedAt = toEpoch(session.endsAt);
+    const suggestedSessionIds = getSuggestedSessions(session, sessions, suggestionLimit);
+    const events: BookingFollowUpEvent[] = [];
+
+    if (
+      booking.status === 'booked' &&
+      booking.attendanceStatus === 'pending' &&
+      sessionStartsAt > nowEpoch &&
+      sessionStartsAt - nowEpoch <= reminderLookaheadMs
+    ) {
+      events.push({
+        type: 'upcoming_session_reminder',
+        key: `${booking.id}:upcoming_session_reminder`,
+        gymId: booking.gymId,
+        branchId: booking.branchId,
+        memberId: booking.memberId,
+        sessionId: booking.sessionId,
+        bookingId: booking.id,
+        sessionTitle: session.title,
+        scheduledFor: new Date(Math.max(nowEpoch, sessionStartsAt - reminderLeadMs)).toISOString(),
+        sessionStartsAt: session.startsAt,
+        attendanceStatus: booking.attendanceStatus,
+        bookingStatus: booking.status,
+        suggestedSessionIds: [],
+      });
+    }
+
+    if (
+      (booking.attendanceStatus === 'missed' || booking.status === 'no_show') &&
+      sessionEndedAt <= nowEpoch &&
+      nowEpoch - sessionEndedAt <= followUpLookbackMs
+    ) {
+      events.push({
+        type: 'missed_session_follow_up',
+        key: `${booking.id}:missed_session_follow_up`,
+        gymId: booking.gymId,
+        branchId: booking.branchId,
+        memberId: booking.memberId,
+        sessionId: booking.sessionId,
+        bookingId: booking.id,
+        sessionTitle: session.title,
+        scheduledFor: now,
+        sessionStartsAt: session.startsAt,
+        attendanceStatus: booking.attendanceStatus,
+        bookingStatus: booking.status,
+        suggestedSessionIds,
+      });
+    }
+
+    if (
+      (booking.status === 'cancelled' || booking.attendanceStatus === 'missed') &&
+      suggestedSessionIds.length > 0
+    ) {
+      events.push({
+        type: 'rebook_invitation',
+        key: `${booking.id}:rebook_invitation`,
+        gymId: booking.gymId,
+        branchId: booking.branchId,
+        memberId: booking.memberId,
+        sessionId: booking.sessionId,
+        bookingId: booking.id,
+        sessionTitle: session.title,
+        scheduledFor: now,
+        sessionStartsAt: session.startsAt,
+        attendanceStatus: booking.attendanceStatus,
+        bookingStatus: booking.status,
+        suggestedSessionIds,
+      });
+    }
+
+    return events;
+  });
+}

--- a/packages/supabase/src/bookings/index.ts
+++ b/packages/supabase/src/bookings/index.ts
@@ -21,6 +21,14 @@ import type {
 } from '@myclup/contracts/bookings';
 import type { ServerSupabaseClient } from '../client';
 import { NotFoundError } from '../auth';
+export {
+  buildBookingCapacityReports,
+  buildBookingFollowUpEvents,
+  type BookingCapacityReport,
+  type BookingFollowUpEvent,
+  type BookingFollowUpBuilderInput,
+  type BookingFollowUpEventType,
+} from './foundations';
 
 type ScopeFilter = {
   gymIds?: string[];

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -56,6 +56,8 @@ export {
 } from './realtime/index';
 
 export {
+  buildBookingCapacityReports,
+  buildBookingFollowUpEvents,
   createBooking,
   cancelBooking,
   getBooking,


### PR DESCRIPTION
## Summary\n- add shared booking capacity-report and follow-up foundation builders in the server layer\n- export canonical reminder, missed-session follow-up, and rebook suggestion derivations for downstream consumers\n- document audit expectations for cross-tenant booking reporting and follow-up reads\n\n## Testing\n- pnpm --filter @myclup/supabase test -- src/bookings/foundations.test.ts\n- pnpm --filter @myclup/supabase lint\n- packages/types/node_modules/.bin/tsc -p packages/types/tsconfig.json && packages/contracts/node_modules/.bin/tsc -p packages/contracts/tsconfig.json && packages/supabase/node_modules/.bin/tsc -p packages/supabase/tsconfig.json --noEmit\n\nCloses #149