### PR TITLE
feat(mobile-user): refine notification center grouping

### DIFF
--- a/apps/mobile-user/src/features/notifications/NotificationCenterScreen.tsx
+++ b/apps/mobile-user/src/features/notifications/NotificationCenterScreen.tsx
@@ -1,10 +1,8 @@
 import { useMemo } from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
+import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { Card, ScreenContainer } from '@myclup/ui-native';
-import { useConversations } from '../chat/useConversations';
-import { useMembership } from '../membership/useMembership';
 import { AppButton } from '../../components/AppButton';
 import { AppIcon } from '../../components/AppIcon';
 import { AppSectionHeader } from '../../components/AppSectionHeader';
@@ -12,7 +10,13 @@ import { AppStateBlock } from '../../components/AppStateBlock';
 import { AppStatusBadge } from '../../components/AppStatusBadge';
 import { AppText } from '../../components/AppText';
 import { appTheme } from '../../theme/appTheme';
-import { buildNotificationSignals } from './notificationCenter';
+import { useConversations } from '../chat/useConversations';
+import { useMembership } from '../membership/useMembership';
+import {
+  buildNotificationCenterDigest,
+  type NotificationCard,
+  type NotificationCardKey,
+} from './notificationCenter';
 
 export function NotificationCenterScreen() {
   const router = useRouter();
@@ -30,153 +34,261 @@ export function NotificationCenterScreen() {
     refresh: refreshConversations,
   } = useConversations();
 
-  const notificationSignals = useMemo(
-    () =>
-      buildNotificationSignals({
-        renewalReason: membershipData.renewalReason,
-        conversations,
-      }),
-    [conversations, membershipData.renewalReason]
+  const digest = useMemo(
+    () => buildNotificationCenterDigest({ membershipData, conversations }),
+    [conversations, membershipData]
   );
 
-  const unreadConversationCount = useMemo(
-    () => conversations.reduce((total, conversation) => total + (conversation.unreadCount ?? 0), 0),
-    [conversations]
-  );
-  const hasError = Boolean(membershipError || conversationsError);
-  const isLoading = membershipLoading || conversationsLoading;
+  const loading = membershipLoading || conversationsLoading;
+  const error = membershipError ?? conversationsError;
+
+  if (loading) {
+    return (
+      <ScreenContainer style={styles.screen}>
+        <AppStateBlock
+          loading
+          title={t('notificationsCenter.loadingTitle')}
+          description={t('notificationsCenter.loadingBody')}
+        />
+      </ScreenContainer>
+    );
+  }
+
+  if (error) {
+    return (
+      <ScreenContainer style={styles.screen}>
+        <AppStateBlock
+          icon="bell-alert-outline"
+          title={t('notificationsCenter.errorTitle')}
+          description={t('notificationsCenter.errorBody')}
+          actionLabel={t('cta.retry')}
+          onAction={() => {
+            void refreshMembership();
+            void refreshConversations();
+          }}
+        />
+      </ScreenContainer>
+    );
+  }
+
+  const liveCards = digest.cards.filter((card) => card.key === 'membership' || card.key === 'chat');
+  const plannedCards = digest.cards.filter((card) => card.key === 'booking' || card.key === 'app');
 
   return (
     <ScreenContainer style={styles.screen}>
       <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
         <Card style={styles.heroCard}>
           <View style={styles.heroTopRow}>
-            <AppStatusBadge label={t('dashboard.notificationsTitle')} tone="primary" />
-            <AppText variant="caption" tone="inverse" style={styles.heroMeta}>
-              {t('shell.subtitle')}
-            </AppText>
+            <AppStatusBadge
+              label={t('notificationsCenter.heroBadge', { count: digest.actionableCount })}
+              tone={digest.actionableCount > 0 ? 'warning' : 'primary'}
+            />
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={t('notificationsCenter.backHome')}
+              onPress={() => router.push('/')}
+              style={({ pressed }) => [styles.backButton, pressed ? styles.pressed : null]}
+            >
+              <AppIcon name="arrow-left" size={16} color={appTheme.colors.primary} />
+              <AppText variant="label" tone="primary">
+                {t('notificationsCenter.backHome')}
+              </AppText>
+            </Pressable>
           </View>
+
           <View style={styles.heroBody}>
-            <AppText variant="title" tone="inverse">
-              {t('notifications.heroTitle')}
+            <AppText variant="title" style={styles.heroTitle}>
+              {t('notificationsCenter.title')}
             </AppText>
-            <AppText variant="subtitle" tone="inverse">
-              {t('notifications.heroSubtitle')}
+            <AppText variant="body" tone="muted">
+              {t('notificationsCenter.subtitle')}
             </AppText>
-          </View>
-          <View style={styles.heroStats}>
-            <View style={styles.heroStat}>
-              <AppText variant="value" tone="inverse">
-                {unreadConversationCount}
-              </AppText>
-              <AppText variant="caption" tone="inverse">
-                {t('notifications.stats.unreadMessages')}
-              </AppText>
-            </View>
-            <View style={styles.heroStat}>
-              <AppText variant="value" tone="inverse">
-                {membershipData.renewalReason
-                  ? t('notifications.stats.actionNeeded')
-                  : t('notifications.stats.clear')}
-              </AppText>
-              <AppText variant="caption" tone="inverse">
-                {t('notifications.stats.membership')}
-              </AppText>
-            </View>
           </View>
         </Card>
 
-        <View style={styles.sectionGap}>
+        <View style={styles.section}>
           <AppSectionHeader
-            title={t('notifications.centerTitle')}
-            subtitle={t('notifications.centerSubtitle')}
+            title={t('notificationsCenter.liveTitle')}
+            subtitle={t('notificationsCenter.liveSubtitle')}
           />
-          {isLoading ? (
-            <AppStateBlock
-              loading
-              title={t('notifications.loadingTitle')}
-              description={t('notifications.loadingBody')}
-            />
-          ) : hasError ? (
-            <AppStateBlock
-              icon="alert-circle-outline"
-              title={t('notifications.errorTitle')}
-              description={t('notifications.errorBody')}
-              actionLabel={t('cta.retry')}
-              onAction={() => {
-                void refreshMembership();
-                void refreshConversations();
-              }}
-            />
-          ) : (
-            <View style={styles.cardStack}>
-              {notificationSignals.map((signal) => (
-                <Card key={signal.key} style={styles.signalCard}>
-                  <View style={styles.signalHeader}>
-                    <View style={styles.signalIconWrap}>
-                      <AppIcon name={signal.icon} size={20} color={appTheme.colors.primary} />
-                    </View>
-                    <View style={styles.signalCopy}>
-                      <AppText variant="subtitle" style={styles.signalTitle}>
-                        {t(signal.titleKey)}
-                      </AppText>
-                      <AppText variant="body" tone="muted">
-                        {t(signal.bodyKey, { count: unreadConversationCount })}
-                      </AppText>
-                    </View>
-                  </View>
-                  <View style={styles.signalFooter}>
-                    <AppStatusBadge
-                      label={t(`notifications.status.${signal.tone}`)}
-                      tone={signal.tone}
-                    />
-                    {signal.actionRoute && signal.actionLabelKey ? (
-                      <AppButton
-                        label={t(signal.actionLabelKey)}
-                        variant="secondary"
-                        onPress={() => {
-                          if (signal.actionRoute) {
-                            router.push(signal.actionRoute);
-                          }
-                        }}
-                      />
-                    ) : null}
-                  </View>
-                </Card>
-              ))}
-            </View>
-          )}
+          <View style={styles.cardGrid}>
+            {liveCards.map((card) => (
+              <NotificationCardView
+                key={card.key}
+                card={card}
+                locale={membershipData.locale}
+                onRoute={(route) => {
+                  if (route) {
+                    router.push(route);
+                  }
+                }}
+              />
+            ))}
+          </View>
         </View>
 
-        <View style={styles.sectionGap}>
+        <View style={styles.section}>
           <AppSectionHeader
-            title={t('notifications.quickLinksTitle')}
-            subtitle={t('notifications.quickLinksSubtitle')}
+            title={t('notificationsCenter.plannedTitle')}
+            subtitle={t('notificationsCenter.plannedSubtitle')}
           />
-          <View style={styles.quickLinks}>
-            <AppButton
-              label={t('cta.openMembership')}
-              icon="credit-card-outline"
-              variant="secondary"
-              onPress={() => router.push('/membership')}
-            />
-            <AppButton
-              label={t('cta.openChat')}
-              icon="chat-outline"
-              variant="secondary"
-              onPress={() => router.push('/chat')}
-            />
-            <AppButton
-              label={t('cta.openProfile')}
-              icon="account-circle-outline"
-              variant="secondary"
-              onPress={() => router.push('/profile')}
-            />
+          <View style={styles.cardGrid}>
+            {plannedCards.map((card) => (
+              <NotificationCardView
+                key={card.key}
+                card={card}
+                locale={membershipData.locale}
+                onRoute={(route) => {
+                  if (route) {
+                    router.push(route);
+                  }
+                }}
+              />
+            ))}
           </View>
         </View>
       </ScrollView>
     </ScreenContainer>
   );
+}
+
+function NotificationCardView({
+  card,
+  locale,
+  onRoute,
+}: {
+  card: NotificationCard;
+  locale: string;
+  onRoute: (route: '/membership' | '/membership/renew' | '/chat' | null) => void;
+}) {
+  const { t } = useTranslation('common');
+  const config = getNotificationCardConfig(card.key);
+  const meta = buildMeta(card, locale, t);
+  const tone = card.state === 'action' ? 'warning' : card.state === 'info' ? 'primary' : 'neutral';
+
+  return (
+    <Card style={styles.notificationCard}>
+      <View style={styles.notificationHeader}>
+        <View style={styles.iconBubble}>
+          <AppIcon name={config.icon} size={18} color={appTheme.colors.primary} />
+        </View>
+        <AppStatusBadge label={t(config.statusKey(card))} tone={tone} />
+      </View>
+
+      <View style={styles.notificationBody}>
+        <AppText variant="subtitle" style={styles.notificationTitle}>
+          {t(config.titleKey)}
+        </AppText>
+        <AppText variant="body" tone="muted">
+          {t(config.bodyKey(card), {
+            count: card.unreadCount ?? 0,
+          })}
+        </AppText>
+        {meta ? (
+          <AppText variant="caption" tone="soft">
+            {meta}
+          </AppText>
+        ) : null}
+      </View>
+
+      {card.route ? (
+        <AppButton
+          label={t(config.actionKey(card))}
+          icon={config.actionIcon}
+          onPress={() => onRoute(card.route)}
+          variant={card.state === 'action' ? 'primary' : 'secondary'}
+        />
+      ) : null}
+    </Card>
+  );
+}
+
+function buildMeta(
+  card: NotificationCard,
+  locale: string,
+  t: (key: string, params?: Record<string, string | number>) => string
+) {
+  if (card.key === 'membership' && card.renewalReason && card.route === '/membership/renew') {
+    return t(`notificationsCenter.cards.membership.meta.${card.renewalReason}`);
+  }
+
+  if (card.key === 'chat' && card.updatedAt) {
+    const formatted = new Intl.DateTimeFormat(locale, {
+      day: 'numeric',
+      month: 'short',
+      hour: 'numeric',
+      minute: '2-digit',
+    }).format(new Date(card.updatedAt));
+
+    return t('notificationsCenter.cards.chat.meta.updatedAt', { date: formatted });
+  }
+
+  return null;
+}
+
+function getNotificationCardConfig(key: NotificationCardKey) {
+  switch (key) {
+    case 'membership':
+      return {
+        icon: 'credit-card-refresh-outline',
+        titleKey: 'notificationsCenter.cards.membership.title',
+        statusKey: (card: NotificationCard) =>
+          `notificationsCenter.cards.membership.status.${card.state}`,
+        bodyKey: (card: NotificationCard) => {
+          if (card.renewalReason === 'expired') {
+            return 'notificationsCenter.cards.membership.body.expired';
+          }
+
+          if (card.renewalReason === 'expiring_soon') {
+            return 'notificationsCenter.cards.membership.body.expiringSoon';
+          }
+
+          if (card.state === 'placeholder') {
+            return 'notificationsCenter.cards.membership.body.placeholder';
+          }
+
+          return 'notificationsCenter.cards.membership.body.stable';
+        },
+        actionKey: (card: NotificationCard) =>
+          card.route === '/membership/renew'
+            ? 'notificationsCenter.cards.membership.action.renew'
+            : 'notificationsCenter.cards.membership.action.open',
+        actionIcon: 'credit-card-outline',
+      };
+    case 'chat':
+      return {
+        icon: 'message-badge-outline',
+        titleKey: 'notificationsCenter.cards.chat.title',
+        statusKey: (card: NotificationCard) =>
+          `notificationsCenter.cards.chat.status.${card.state}`,
+        bodyKey: (card: NotificationCard) =>
+          card.state === 'action'
+            ? 'notificationsCenter.cards.chat.body.unread'
+            : card.state === 'info'
+              ? 'notificationsCenter.cards.chat.body.stable'
+              : 'notificationsCenter.cards.chat.body.placeholder',
+        actionKey: () => 'notificationsCenter.cards.chat.action.open',
+        actionIcon: 'chat-outline',
+      };
+    case 'booking':
+      return {
+        icon: 'calendar-clock-outline',
+        titleKey: 'notificationsCenter.cards.booking.title',
+        statusKey: () => 'notificationsCenter.cards.booking.status.placeholder',
+        bodyKey: () => 'notificationsCenter.cards.booking.body.placeholder',
+        actionKey: () => 'notificationsCenter.cards.booking.action.disabled',
+        actionIcon: 'calendar-plus-outline',
+      };
+    case 'app':
+      return {
+        icon: 'bell-ring-outline',
+        titleKey: 'notificationsCenter.cards.app.title',
+        statusKey: () => 'notificationsCenter.cards.app.status.placeholder',
+        bodyKey: () => 'notificationsCenter.cards.app.body.placeholder',
+        actionKey: () => 'notificationsCenter.cards.app.action.disabled',
+        actionIcon: 'bell-outline',
+      };
+  }
 }
 
 const styles = StyleSheet.create({
@@ -192,69 +304,62 @@ const styles = StyleSheet.create({
     gap: appTheme.spacing.xl,
   },
   heroCard: {
-    backgroundColor: appTheme.colors.primary,
-    borderColor: 'rgba(255,255,255,0.16)',
     gap: appTheme.spacing.lg,
   },
   heroTopRow: {
-    gap: 8,
-  },
-  heroMeta: {
-    opacity: 0.88,
-  },
-  heroBody: {
-    gap: 10,
-  },
-  heroStats: {
-    flexDirection: 'row',
-    gap: appTheme.spacing.md,
-    flexWrap: 'wrap',
-  },
-  heroStat: {
-    minWidth: 132,
-    gap: 4,
-    paddingHorizontal: appTheme.spacing.md,
-    paddingVertical: appTheme.spacing.sm,
-    borderRadius: appTheme.radii.lg,
-    backgroundColor: 'rgba(255,255,255,0.12)',
-  },
-  sectionGap: {
-    gap: appTheme.spacing.md,
-  },
-  cardStack: {
-    gap: appTheme.spacing.md,
-  },
-  signalCard: {
-    gap: appTheme.spacing.md,
-  },
-  signalHeader: {
-    flexDirection: 'row',
-    alignItems: 'flex-start',
-    gap: appTheme.spacing.md,
-  },
-  signalIconWrap: {
-    width: 42,
-    height: 42,
-    borderRadius: appTheme.radii.pill,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: appTheme.colors.surfaceMuted,
-  },
-  signalCopy: {
-    flex: 1,
-    gap: 4,
-  },
-  signalTitle: {
-    fontWeight: '800',
-  },
-  signalFooter: {
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
     gap: appTheme.spacing.md,
-    flexWrap: 'wrap',
   },
-  quickLinks: {
-    gap: appTheme.spacing.sm,
+  heroBody: {
+    gap: 8,
+  },
+  backButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: appTheme.spacing.md,
+    paddingVertical: appTheme.spacing.sm,
+    borderRadius: appTheme.radii.pill,
+    backgroundColor: appTheme.colors.primarySoft,
+  },
+  heroTitle: {
+    fontSize: 28,
+    lineHeight: 34,
+  },
+  section: {
+    gap: appTheme.spacing.md,
+  },
+  cardGrid: {
+    gap: appTheme.spacing.md,
+  },
+  notificationCard: {
+    gap: appTheme.spacing.md,
+  },
+  notificationHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: appTheme.spacing.md,
+  },
+  iconBubble: {
+    width: 40,
+    height: 40,
+    borderRadius: appTheme.radii.pill,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: appTheme.colors.primarySoft,
+  },
+  notificationBody: {
+    gap: 8,
+  },
+  notificationTitle: {
+    fontSize: 17,
+    lineHeight: 23,
+    fontWeight: '800',
+  },
+  pressed: {
+    opacity: 0.9,
   },
 });

--- a/apps/mobile-user/src/features/notifications/notificationCenter.test.ts
+++ b/apps/mobile-user/src/features/notifications/notificationCenter.test.ts
@@ -1,51 +1,85 @@
 import { describe, expect, it } from 'vitest';
-import { buildNotificationSignals } from './notificationCenter';
+import { buildNotificationCenterDigest } from './notificationCenter';
+import type { MembershipScreenData } from '../membership/types';
+import type { ConversationWithUnread } from '../chat/useConversations';
 
-describe('notification center helpers', () => {
-  it('builds actionable membership and chat signals before placeholders', () => {
-    const items = buildNotificationSignals({
-      renewalReason: 'expired',
-      conversations: [
-        {
-          id: '11111111-1111-1111-1111-111111111111',
-          gymId: '22222222-2222-2222-2222-222222222222',
-          branchId: null,
-          type: 'support',
-          metadata: {},
-          createdAt: '2026-03-19T08:00:00.000Z',
-          updatedAt: '2026-03-19T09:00:00.000Z',
-          unreadCount: 3,
-        },
-      ],
-    });
+function createMembershipData(overrides: Partial<MembershipScreenData> = {}): MembershipScreenData {
+  return {
+    locale: 'en',
+    memberId: 'member-1',
+    membership: null,
+    plan: null,
+    renewalOptions: [],
+    canRenew: false,
+    renewalReason: null,
+    ...overrides,
+  };
+}
 
-    expect(items.map((item) => item.key)).toEqual(['membership', 'chat', 'booking', 'updates']);
-    expect(items[0]).toMatchObject({
-      actionRoute: '/membership/renew',
-      actionLabelKey: 'cta.renewNow',
-      tone: 'warning',
+describe('buildNotificationCenterDigest', () => {
+  it('surfaces membership renewal and unread chat as actionable cards', () => {
+    const membershipData = createMembershipData({
+      membership: {
+        id: 'membership-1',
+        planId: 'plan-1',
+        memberId: 'member-1',
+        gymId: 'gym-1',
+        branchId: null,
+        status: 'active',
+        validFrom: '2026-03-01T00:00:00.000Z',
+        validUntil: '2026-03-31T00:00:00.000Z',
+        remainingSessions: 4,
+        freezeStartAt: null,
+        freezeEndAt: null,
+        entitledBranchIds: [],
+        createdAt: '2026-03-01T00:00:00.000Z',
+        updatedAt: '2026-03-01T00:00:00.000Z',
+      },
+      canRenew: true,
+      renewalReason: 'expiring_soon',
     });
-    expect(items[1]).toMatchObject({
-      actionRoute: '/chat',
-      actionLabelKey: 'cta.openChat',
-      tone: 'primary',
+    const conversations: ConversationWithUnread[] = [
+      {
+        id: 'conversation-1',
+        type: 'support',
+        gymId: 'gym-1',
+        branchId: null,
+        metadata: {},
+        unreadCount: 2,
+        createdAt: '2026-03-18T10:00:00.000Z',
+        updatedAt: '2026-03-19T10:00:00.000Z',
+      },
+    ];
+
+    const digest = buildNotificationCenterDigest({ membershipData, conversations });
+
+    expect(digest.actionableCount).toBe(2);
+    expect(digest.cards[0]).toMatchObject({
+      key: 'membership',
+      state: 'action',
+      route: '/membership/renew',
+      renewalReason: 'expiring_soon',
+    });
+    expect(digest.cards[1]).toMatchObject({
+      key: 'chat',
+      state: 'action',
+      route: '/chat',
+      unreadCount: 2,
     });
   });
 
-  it('falls back to an all-caught-up signal when no actionable state exists', () => {
-    const items = buildNotificationSignals({
-      renewalReason: null,
+  it('keeps booking and app cards as placeholders and degrades gracefully with no data', () => {
+    const digest = buildNotificationCenterDigest({
+      membershipData: createMembershipData(),
       conversations: [],
     });
 
-    expect(items[0]).toMatchObject({
-      key: 'updates',
-      titleKey: 'notifications.caughtUpTitle',
-      tone: 'success',
-    });
-    expect(items[1]).toMatchObject({
-      key: 'booking',
-      tone: 'neutral',
-    });
+    expect(digest.actionableCount).toBe(0);
+    expect(digest.cards).toEqual([
+      { key: 'membership', route: '/membership', state: 'placeholder' },
+      { key: 'chat', route: '/chat', state: 'placeholder' },
+      { key: 'booking', route: null, state: 'placeholder' },
+      { key: 'app', route: null, state: 'placeholder' },
+    ]);
   });
 });

--- a/apps/mobile-user/src/features/notifications/notificationCenter.ts
+++ b/apps/mobile-user/src/features/notifications/notificationCenter.ts
@@ -1,94 +1,109 @@
 import type { ConversationWithUnread } from '../chat/useConversations';
-import type { RenewalReason } from '../membership/types';
+import type { MembershipScreenData, RenewalReason } from '../membership/types';
 
-export type NotificationSignalTone = 'primary' | 'success' | 'warning' | 'neutral';
+export type NotificationCardKey = 'membership' | 'chat' | 'booking' | 'app';
+export type NotificationCardState = 'action' | 'info' | 'placeholder';
 
-export type NotificationSignal = {
-  key: 'membership' | 'chat' | 'booking' | 'updates';
-  icon: string;
-  titleKey: string;
-  bodyKey: string;
-  tone: NotificationSignalTone;
-  actionRoute?: '/membership' | '/membership/renew' | '/chat';
-  actionLabelKey?: string;
+export type NotificationCard = {
+  key: NotificationCardKey;
+  state: NotificationCardState;
+  route: '/membership' | '/membership/renew' | '/chat' | null;
+  unreadCount?: number;
+  updatedAt?: string;
+  renewalReason?: RenewalReason;
 };
 
-type BuildNotificationSignalsInput = {
-  renewalReason: RenewalReason;
+export type NotificationCenterDigest = {
+  actionableCount: number;
+  cards: NotificationCard[];
+};
+
+type NotificationCenterInput = {
+  membershipData: MembershipScreenData;
   conversations: ConversationWithUnread[];
 };
 
-export function buildNotificationSignals({
-  renewalReason,
+export function buildNotificationCenterDigest({
+  membershipData,
   conversations,
-}: BuildNotificationSignalsInput): NotificationSignal[] {
-  const unreadThreads = conversations.filter((conversation) => (conversation.unreadCount ?? 0) > 0);
-  const unreadCount = unreadThreads.reduce(
-    (total, conversation) => total + (conversation.unreadCount ?? 0),
+}: NotificationCenterInput): NotificationCenterDigest {
+  const unreadCount = conversations.reduce(
+    (count, conversation) => count + Math.max(conversation.unreadCount ?? 0, 0),
     0
   );
-  const signals: NotificationSignal[] = [];
+  const latestConversation = [...conversations].sort((left, right) =>
+    right.updatedAt.localeCompare(left.updatedAt)
+  )[0];
 
-  if (renewalReason) {
-    signals.push({
+  const cards: NotificationCard[] = [
+    buildMembershipCard(membershipData),
+    buildChatCard(unreadCount, latestConversation?.updatedAt),
+    {
+      key: 'booking',
+      state: 'placeholder',
+      route: null,
+    },
+    {
+      key: 'app',
+      state: 'placeholder',
+      route: null,
+    },
+  ];
+
+  return {
+    actionableCount: cards.filter((card) => card.state === 'action').length,
+    cards,
+  };
+}
+
+function buildMembershipCard(membershipData: MembershipScreenData): NotificationCard {
+  if (!membershipData.membership) {
+    return {
       key: 'membership',
-      icon: renewalReason === 'expired' ? 'alert-circle-outline' : 'clock-alert-outline',
-      titleKey:
-        renewalReason === 'expired'
-          ? 'notifications.membershipExpiredTitle'
-          : 'notifications.membershipExpiringTitle',
-      bodyKey:
-        renewalReason === 'expired'
-          ? 'notifications.membershipExpiredBody'
-          : 'notifications.membershipExpiringBody',
-      tone: 'warning',
-      actionRoute: '/membership/renew',
-      actionLabelKey: 'cta.renewNow',
-    });
+      state: 'placeholder',
+      route: '/membership',
+    };
   }
 
+  if (membershipData.renewalReason) {
+    return {
+      key: 'membership',
+      state: 'action',
+      route: '/membership/renew',
+      renewalReason: membershipData.renewalReason,
+    };
+  }
+
+  return {
+    key: 'membership',
+    state: 'info',
+    route: '/membership',
+  };
+}
+
+function buildChatCard(unreadCount: number, updatedAt?: string): NotificationCard {
   if (unreadCount > 0) {
-    signals.push({
+    return {
       key: 'chat',
-      icon: 'chat-processing-outline',
-      titleKey: 'notifications.chatUnreadTitle',
-      bodyKey:
-        unreadThreads.length > 1
-          ? 'notifications.chatUnreadBodyMany'
-          : 'notifications.chatUnreadBodySingle',
-      tone: 'primary',
-      actionRoute: '/chat',
-      actionLabelKey: 'cta.openChat',
-    });
+      state: 'action',
+      route: '/chat',
+      unreadCount,
+      updatedAt,
+    };
   }
 
-  if (signals.length === 0) {
-    signals.push({
-      key: 'updates',
-      icon: 'bell-check-outline',
-      titleKey: 'notifications.caughtUpTitle',
-      bodyKey: 'notifications.caughtUpBody',
-      tone: 'success',
-    });
+  if (updatedAt) {
+    return {
+      key: 'chat',
+      state: 'info',
+      route: '/chat',
+      updatedAt,
+    };
   }
 
-  signals.push({
-    key: 'booking',
-    icon: 'calendar-clock-outline',
-    titleKey: 'notifications.bookingPlaceholderTitle',
-    bodyKey: 'notifications.bookingPlaceholderBody',
-    tone: 'neutral',
-  });
-
-  if (!signals.some((signal) => signal.key === 'updates')) {
-    signals.push({
-      key: 'updates',
-      icon: 'bell-badge-outline',
-      titleKey: 'notifications.updatesPlaceholderTitle',
-      bodyKey: 'notifications.updatesPlaceholderBody',
-      tone: 'neutral',
-    });
-  }
-
-  return signals;
+  return {
+    key: 'chat',
+    state: 'placeholder',
+    route: '/chat',
+  };
 }

--- a/packages/i18n/src/__tests__/common-notifications-keys.test.ts
+++ b/packages/i18n/src/__tests__/common-notifications-keys.test.ts
@@ -15,8 +15,20 @@ function flattenKeys(value: Record<string, unknown>, prefix = ''): string[] {
 
 describe('common notifications keys', () => {
   it('keeps notifications/reminder copy in parity across locales', () => {
-    expect(flattenKeys({ notifications: commonTr.notifications } as Record<string, unknown>)).toEqual(
-      flattenKeys({ notifications: commonEn.notifications } as Record<string, unknown>)
+    const branches = ['notifications', 'notificationsCenter'];
+    const enKeys = branches.flatMap((branch) =>
+      flattenKeys({ [branch]: commonEn[branch as keyof typeof commonEn] } as Record<
+        string,
+        unknown
+      >)
     );
+    const trKeys = branches.flatMap((branch) =>
+      flattenKeys({ [branch]: commonTr[branch as keyof typeof commonTr] } as Record<
+        string,
+        unknown
+      >)
+    );
+
+    expect(trKeys).toEqual(enKeys);
   });
 });

--- a/packages/i18n/src/namespaces/common/en.json
+++ b/packages/i18n/src/namespaces/common/en.json
@@ -188,6 +188,87 @@
       "neutral": "Coming next"
     }
   },
+  "notificationsCenter": {
+    "loadingTitle": "Loading reminder center...",
+    "loadingBody": "Gathering the latest membership and chat signals.",
+    "errorTitle": "Reminder center unavailable",
+    "errorBody": "Try again to reload the latest member reminders.",
+    "heroBadge": "{{count}} active reminders",
+    "backHome": "Back to home",
+    "title": "Notifications and reminders",
+    "subtitle": "Track live member signals in one place while future delivery channels stay clearly marked as placeholders.",
+    "liveTitle": "Live now",
+    "liveSubtitle": "These cards are powered by membership and chat data already available in the app.",
+    "plannedTitle": "Coming next",
+    "plannedSubtitle": "These slots stay visible so booking and app-level reminders never appear as silent gaps.",
+    "cards": {
+      "membership": {
+        "title": "Membership status",
+        "status": {
+          "action": "Needs action",
+          "info": "Stable",
+          "placeholder": "No active plan"
+        },
+        "body": {
+          "expired": "Your membership has expired. Renew now to restore access.",
+          "expiringSoon": "Your renewal window is open. Renew before access is interrupted.",
+          "stable": "Your current membership is active and available in the membership hub.",
+          "placeholder": "A membership reminder card will appear here once a plan is assigned."
+        },
+        "action": {
+          "renew": "Review renewal",
+          "open": "Open membership"
+        },
+        "meta": {
+          "expired": "Expired memberships stay actionable until renewal is submitted.",
+          "expiring_soon": "Renew before the next expiry checkpoint to avoid interruptions."
+        }
+      },
+      "chat": {
+        "title": "Chat follow-up",
+        "status": {
+          "action": "Unread messages",
+          "info": "Conversation open",
+          "placeholder": "No conversations yet"
+        },
+        "body": {
+          "unread": "You have {{count}} unread messages waiting for follow-up.",
+          "stable": "Your latest conversation is synced and available in chat.",
+          "placeholder": "A chat reminder card will appear here once a conversation starts."
+        },
+        "action": {
+          "open": "Open chat"
+        },
+        "meta": {
+          "updatedAt": "Updated {{date}}"
+        }
+      },
+      "booking": {
+        "title": "Booking reminders",
+        "status": {
+          "placeholder": "Placeholder"
+        },
+        "body": {
+          "placeholder": "Class reminders and waitlist nudges will land here when booking delivery is ready."
+        },
+        "action": {
+          "disabled": "Booking soon"
+        }
+      },
+      "app": {
+        "title": "App updates",
+        "status": {
+          "placeholder": "Placeholder"
+        },
+        "body": {
+          "placeholder": "Push alerts, campaigns, and release notes will appear here once delivery channels are enabled."
+        },
+        "action": {
+          "disabled": "App updates soon"
+        }
+      }
+    }
+  },
   "profile": {
     "title": "Profile and settings",
     "subtitle": "Manage the member details supported today and track which settings arrive next.",

--- a/packages/i18n/src/namespaces/common/tr.json
+++ b/packages/i18n/src/namespaces/common/tr.json
@@ -188,6 +188,87 @@
       "neutral": "Sıradaki"
     }
   },
+  "notificationsCenter": {
+    "loadingTitle": "Hatırlatma merkezi yükleniyor...",
+    "loadingBody": "Son üyelik ve sohbet sinyalleri toplanıyor.",
+    "errorTitle": "Hatırlatma merkezi açılamadı",
+    "errorBody": "Son üye hatırlatmalarını yeniden yüklemek için tekrar deneyin.",
+    "heroBadge": "{{count}} aktif hatırlatma",
+    "backHome": "Ana sayfaya dön",
+    "title": "Bildirimler ve hatırlatmalar",
+    "subtitle": "Canlı üye sinyallerini tek yerde takip edin; gelecekteki teslimat kanalları ise açık yer tutucular olarak kalsın.",
+    "liveTitle": "Şimdi canlı",
+    "liveSubtitle": "Bu kartlar uygulamada zaten mevcut olan üyelik ve sohbet verileriyle beslenir.",
+    "plannedTitle": "Sıradaki adım",
+    "plannedSubtitle": "Rezervasyon ve uygulama seviyesi hatırlatmalar sessiz boşluklara dönüşmesin diye bu alanlar görünür kalır.",
+    "cards": {
+      "membership": {
+        "title": "Üyelik durumu",
+        "status": {
+          "action": "Aksiyon gerekli",
+          "info": "Dengede",
+          "placeholder": "Aktif plan yok"
+        },
+        "body": {
+          "expired": "Üyeliğinizin süresi doldu. Erişimi geri almak için şimdi yenileyin.",
+          "expiringSoon": "Yenileme pencereniz açıldı. Erişim kesilmeden önce yenileyin.",
+          "stable": "Mevcut üyeliğiniz aktif ve üyelik merkezinden erişilebilir durumda.",
+          "placeholder": "Bir plan atandığında üyelik hatırlatma kartı burada görünecek."
+        },
+        "action": {
+          "renew": "Yenilemeyi incele",
+          "open": "Üyeliği aç"
+        },
+        "meta": {
+          "expired": "Süresi dolan üyelikler, yenileme gönderilene kadar aksiyon gerektirir.",
+          "expiring_soon": "Kesinti yaşamamak için bir sonraki sona erme eşiğinden önce yenileyin."
+        }
+      },
+      "chat": {
+        "title": "Sohbet takibi",
+        "status": {
+          "action": "Okunmamış mesaj",
+          "info": "Görüşme açık",
+          "placeholder": "Henüz görüşme yok"
+        },
+        "body": {
+          "unread": "Takip bekleyen {{count}} okunmamış mesajınız var.",
+          "stable": "Son görüşmeniz senkronize edildi ve sohbet içinde hazır.",
+          "placeholder": "Bir görüşme başladığında sohbet hatırlatma kartı burada görünecek."
+        },
+        "action": {
+          "open": "Sohbeti aç"
+        },
+        "meta": {
+          "updatedAt": "{{date}} tarihinde güncellendi"
+        }
+      },
+      "booking": {
+        "title": "Rezervasyon hatırlatmaları",
+        "status": {
+          "placeholder": "Yer tutucu"
+        },
+        "body": {
+          "placeholder": "Rezervasyon teslimatı hazır olduğunda ders hatırlatmaları ve bekleme listesi uyarıları burada görünecek."
+        },
+        "action": {
+          "disabled": "Rezervasyon yakında"
+        }
+      },
+      "app": {
+        "title": "Uygulama güncellemeleri",
+        "status": {
+          "placeholder": "Yer tutucu"
+        },
+        "body": {
+          "placeholder": "Teslimat kanalları etkinleştiğinde push uyarıları, kampanyalar ve sürüm notları burada görünecek."
+        },
+        "action": {
+          "disabled": "Uygulama güncellemeleri yakında"
+        }
+      }
+    }
+  },
   "profile": {
     "title": "Profil ve ayarlar",
     "subtitle": "Bugün desteklenen üye alanlarını yönet ve sıradaki ayar alanlarını tek ekranda gör.",


### PR DESCRIPTION
## Summary
- regroup the member notification center into explicit live vs planned cards
- keep the existing route/surface but upgrade the card model, metadata, and placeholder clarity
- add `notificationsCenter` common locale copy and extend locale parity coverage

## Verification
- `pnpm --filter @myclup/mobile-user lint`
- `pnpm --filter @myclup/mobile-user test -- notificationCenter`
- `pnpm --filter @myclup/i18n test -- common-notifications-keys`

## Notes
- `pnpm --filter @myclup/mobile-user typecheck` is still failing on clean `master` because workspace package resolution is already broken for `@myclup/contracts`, `@myclup/api-client`, `@myclup/i18n`, and `@myclup/types`. This follow-up does not introduce a new typecheck class beyond that baseline.