### PR TITLE
feat(supabase): SSR/browser anon clients and request helpers (#55)

### DIFF
--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -20,6 +20,16 @@ export {
 } from './client/index';
 
 export {
+  createAnonBrowserClient,
+  createAnonSsrServerClient,
+  type AnonSupabaseClient,
+  type CreateAnonBrowserClientOptions,
+  type CreateAnonSsrServerClientOptions,
+} from './ssr/anon-clients';
+
+export { getUserFromRequest, getTenantScope } from './server-helpers';
+
+export {
   getSession,
   getCurrentUser,
   createUserScopedClient,

--- a/packages/supabase/src/server-helpers.ts
+++ b/packages/supabase/src/server-helpers.ts
@@ -1,0 +1,33 @@
+/**
+ * Request-oriented helpers (Epic #14 / issue #55 naming).
+ *
+ * Prefer the canonical names {@link getSession} and {@link resolveTenantScope} in new code;
+ * these exports preserve the task contract and delegate to the real implementations.
+ */
+
+import type { User } from '@supabase/supabase-js';
+import type { TenantScope } from '@myclup/types';
+import type { ServerSupabaseClient } from './client/create-server-client';
+import { getSession, type AuthRequest } from './auth/get-session';
+import { resolveTenantScope } from './auth/permissions';
+
+/**
+ * Returns the authenticated Supabase user for the request, or null.
+ * Delegates to {@link getSession} and reads `session.user`.
+ */
+export async function getUserFromRequest(req: AuthRequest): Promise<User | null> {
+  const session = await getSession(req);
+  return session?.user ?? null;
+}
+
+/**
+ * Resolves tenant scopes for a user. Delegates to {@link resolveTenantScope}.
+ */
+export async function getTenantScope(
+  client: ServerSupabaseClient,
+  userId: string,
+  gymId?: string,
+  branchId?: string
+): Promise<TenantScope[]> {
+  return resolveTenantScope(client, userId, gymId, branchId);
+}

--- a/packages/supabase/src/ssr/anon-clients.test.ts
+++ b/packages/supabase/src/ssr/anon-clients.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { createAnonBrowserClient, createAnonSsrServerClient } from './anon-clients';
+
+describe('createAnonBrowserClient', () => {
+  it('throws when supabaseUrl is missing', () => {
+    expect(() => createAnonBrowserClient({ supabaseUrl: '', supabaseAnonKey: 'anon' })).toThrow(
+      /supabaseUrl is required/
+    );
+  });
+
+  it('throws when anon key is missing', () => {
+    expect(() =>
+      createAnonBrowserClient({ supabaseUrl: 'https://x.supabase.co', supabaseAnonKey: '  ' })
+    ).toThrow(/supabaseAnonKey is required/);
+  });
+
+  it('returns a Supabase client when options are valid', () => {
+    const client = createAnonBrowserClient({
+      supabaseUrl: 'https://example.supabase.co',
+      supabaseAnonKey: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test',
+    });
+    expect(client).toBeDefined();
+    expect(typeof client.from).toBe('function');
+  });
+});
+
+describe('createAnonSsrServerClient', () => {
+  const cookies = {
+    getAll: () => [] as { name: string; value: string }[],
+  };
+
+  it('throws when supabaseUrl is missing', () => {
+    expect(() =>
+      createAnonSsrServerClient({
+        supabaseUrl: '',
+        supabaseAnonKey: 'anon',
+        cookies,
+      })
+    ).toThrow(/supabaseUrl is required/);
+  });
+
+  it('throws when anon key is missing', () => {
+    expect(() =>
+      createAnonSsrServerClient({
+        supabaseUrl: 'https://x.supabase.co',
+        supabaseAnonKey: '',
+        cookies,
+      })
+    ).toThrow(/supabaseAnonKey is required/);
+  });
+
+  it('returns a Supabase client when options are valid', () => {
+    const client = createAnonSsrServerClient({
+      supabaseUrl: 'https://example.supabase.co',
+      supabaseAnonKey: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test',
+      cookies,
+    });
+    expect(client).toBeDefined();
+    expect(typeof client.from).toBe('function');
+  });
+});

--- a/packages/supabase/src/ssr/anon-clients.ts
+++ b/packages/supabase/src/ssr/anon-clients.ts
@@ -1,0 +1,63 @@
+/**
+ * Supabase clients using the **anon** key and `@supabase/ssr`.
+ *
+ * Use `createAnonBrowserClient` in browser / client components.
+ * Use `createAnonSsrServerClient` in SSR routes (Next.js App Router, middleware, etc.)
+ * with a correct `cookies` adapter.
+ *
+ * For privileged **service role** access (RLS bypass), use {@link createServerClient}
+ * from `./client` instead — never expose the service role key to clients.
+ */
+
+import { createBrowserClient, createServerClient } from '@supabase/ssr';
+import type { CookieMethodsServer } from '@supabase/ssr';
+import type { Database } from '../generated/database.types';
+
+export interface CreateAnonBrowserClientOptions {
+  supabaseUrl: string;
+  /** Public anon key — safe for browser bundles */
+  supabaseAnonKey: string;
+}
+
+/**
+ * Browser Supabase client (anon key, typed `Database`).
+ * Callers pass URL and key from env at the call site — this module does not read `process.env`.
+ */
+export function createAnonBrowserClient(options: CreateAnonBrowserClientOptions) {
+  const { supabaseUrl, supabaseAnonKey } = options;
+  if (!supabaseUrl?.trim()) {
+    throw new Error('createAnonBrowserClient: supabaseUrl is required');
+  }
+  if (!supabaseAnonKey?.trim()) {
+    throw new Error(
+      'createAnonBrowserClient: supabaseAnonKey is required (anon key only — never service role)'
+    );
+  }
+  return createBrowserClient<Database>(supabaseUrl, supabaseAnonKey);
+}
+
+export interface CreateAnonSsrServerClientOptions {
+  supabaseUrl: string;
+  supabaseAnonKey: string;
+  cookies: CookieMethodsServer;
+}
+
+/**
+ * Server-side SSR Supabase client (anon key + cookie session).
+ * Configure `cookies` per your framework (e.g. Next.js `cookies()` from `next/headers`).
+ */
+export function createAnonSsrServerClient(options: CreateAnonSsrServerClientOptions) {
+  const { supabaseUrl, supabaseAnonKey, cookies } = options;
+  if (!supabaseUrl?.trim()) {
+    throw new Error('createAnonSsrServerClient: supabaseUrl is required');
+  }
+  if (!supabaseAnonKey?.trim()) {
+    throw new Error(
+      'createAnonSsrServerClient: supabaseAnonKey is required (anon key only — never service role)'
+    );
+  }
+  return createServerClient<Database>(supabaseUrl, supabaseAnonKey, { cookies });
+}
+
+/** Anon-key Supabase client returned by {@link createAnonBrowserClient} / {@link createAnonSsrServerClient}. */
+export type AnonSupabaseClient = ReturnType<typeof createAnonBrowserClient>;


### PR DESCRIPTION
## Summary
- `createAnonBrowserClient` / `createAnonSsrServerClient` — `@supabase/ssr` + anon key, callers pass URL/key
- `getUserFromRequest`, `getTenantScope` — delegate to `getSession` / `resolveTenantScope`
- Tests: `anon-clients.test.ts`

Closes #55

Made with [Cursor](https://cursor.com)