### PR TITLE
feat(contracts): common pagination, locale, and API error schemas (#57)

### DIFF
--- a/packages/contracts/src/common/error.test.ts
+++ b/packages/contracts/src/common/error.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { ApiErrorResponseSchema } from './error';
+
+describe('ApiErrorResponseSchema', () => {
+  it('parses minimal valid error', () => {
+    expect(ApiErrorResponseSchema.parse({ code: 'ERR', message: 'oops' })).toEqual({
+      code: 'ERR',
+      message: 'oops',
+    });
+  });
+
+  it('accepts optional details', () => {
+    expect(
+      ApiErrorResponseSchema.parse({
+        code: 'E1',
+        message: 'bad',
+        details: { field: 'x' },
+      })
+    ).toEqual({
+      code: 'E1',
+      message: 'bad',
+      details: { field: 'x' },
+    });
+  });
+
+  it('rejects missing code', () => {
+    expect(ApiErrorResponseSchema.safeParse({ message: 'm' }).success).toBe(false);
+  });
+
+  it('rejects empty code', () => {
+    expect(ApiErrorResponseSchema.safeParse({ code: '', message: 'm' }).success).toBe(false);
+  });
+
+  it('rejects empty message', () => {
+    expect(ApiErrorResponseSchema.safeParse({ code: 'c', message: '' }).success).toBe(false);
+  });
+});

--- a/packages/contracts/src/common/error.ts
+++ b/packages/contracts/src/common/error.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+/**
+ * Standard JSON error envelope for BFF / API routes.
+ */
+export const ApiErrorResponseSchema = z.object({
+  code: z.string().min(1, 'code must be non-empty'),
+  message: z.string().min(1, 'message must be non-empty'),
+  details: z.unknown().optional(),
+});
+
+export type ApiErrorResponse = z.infer<typeof ApiErrorResponseSchema>;

--- a/packages/contracts/src/common/index.ts
+++ b/packages/contracts/src/common/index.ts
@@ -1,5 +1,6 @@
 /**
- * @myclup/contracts/common — Shared common schemas and utilities.
- * Domain-specific common schemas will be added as needed.
+ * @myclup/contracts/common — Shared pagination, locale, and error schemas.
  */
-export {};
+export * from './pagination';
+export * from './locale';
+export * from './error';

--- a/packages/contracts/src/common/locale.test.ts
+++ b/packages/contracts/src/common/locale.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { LocaleCodeSchema, LocalePreferenceSchema } from './locale';
+
+describe('LocaleCodeSchema', () => {
+  it('parses supported locales', () => {
+    expect(LocaleCodeSchema.parse('tr')).toBe('tr');
+    expect(LocaleCodeSchema.parse('en')).toBe('en');
+  });
+
+  it('rejects unknown locale', () => {
+    expect(LocaleCodeSchema.safeParse('de').success).toBe(false);
+  });
+});
+
+describe('LocalePreferenceSchema', () => {
+  it('accepts locale only', () => {
+    expect(LocalePreferenceSchema.parse({ locale: 'en' })).toEqual({ locale: 'en' });
+  });
+
+  it('accepts locale with fallback', () => {
+    expect(LocalePreferenceSchema.parse({ locale: 'tr', fallbackLocale: 'en' })).toEqual({
+      locale: 'tr',
+      fallbackLocale: 'en',
+    });
+  });
+
+  it('rejects invalid fallback', () => {
+    expect(LocalePreferenceSchema.safeParse({ locale: 'en', fallbackLocale: 'xx' }).success).toBe(
+      false
+    );
+  });
+});

--- a/packages/contracts/src/common/locale.ts
+++ b/packages/contracts/src/common/locale.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+import { SUPPORTED_LOCALES, type SupportedLocale } from '@myclup/types';
+
+const localeTuple = SUPPORTED_LOCALES as unknown as [SupportedLocale, ...SupportedLocale[]];
+
+/** Single locale code — aligned with {@link SupportedLocale} in `@myclup/types`. */
+export const LocaleCodeSchema = z.enum(localeTuple);
+
+/** User-facing locale preference payload (API body fragments). */
+export const LocalePreferenceSchema = z.object({
+  locale: LocaleCodeSchema,
+  fallbackLocale: LocaleCodeSchema.optional(),
+});
+
+export type LocalePreference = z.infer<typeof LocalePreferenceSchema>;

--- a/packages/contracts/src/common/pagination.test.ts
+++ b/packages/contracts/src/common/pagination.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { PaginationRequestSchema, PaginationResponseSchema } from './pagination';
+
+describe('PaginationRequestSchema', () => {
+  it('parses empty object (all optional)', () => {
+    expect(PaginationRequestSchema.parse({})).toEqual({});
+  });
+
+  it('accepts optional cursor', () => {
+    expect(PaginationRequestSchema.parse({ cursor: 'abc' })).toEqual({ cursor: 'abc' });
+  });
+
+  it('accepts valid limit', () => {
+    expect(PaginationRequestSchema.parse({ limit: 50 })).toEqual({ limit: 50 });
+  });
+
+  it('rejects non-positive limit', () => {
+    expect(PaginationRequestSchema.safeParse({ limit: 0 }).success).toBe(false);
+    expect(PaginationRequestSchema.safeParse({ limit: -3 }).success).toBe(false);
+  });
+
+  it('rejects limit over 100', () => {
+    expect(PaginationRequestSchema.safeParse({ limit: 101 }).success).toBe(false);
+  });
+});
+
+describe('PaginationResponseSchema', () => {
+  it('requires has_more and next_cursor', () => {
+    expect(
+      PaginationResponseSchema.parse({
+        next_cursor: null,
+        has_more: false,
+      })
+    ).toEqual({ next_cursor: null, has_more: false });
+  });
+
+  it('accepts optional total', () => {
+    expect(
+      PaginationResponseSchema.parse({
+        next_cursor: 'x',
+        has_more: true,
+        total: 42,
+      })
+    ).toEqual({ next_cursor: 'x', has_more: true, total: 42 });
+  });
+
+  it('rejects missing has_more', () => {
+    expect(PaginationResponseSchema.safeParse({ next_cursor: null }).success).toBe(false);
+  });
+});

--- a/packages/contracts/src/common/pagination.ts
+++ b/packages/contracts/src/common/pagination.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+/**
+ * Cursor-based pagination request fragment (query/body).
+ * `limit` is optional; when present it must be a positive integer ≤ 100.
+ */
+export const PaginationRequestSchema = z.object({
+  cursor: z.string().optional(),
+  limit: z.coerce
+    .number()
+    .int('limit must be an integer')
+    .positive('limit must be positive')
+    .max(100, 'limit must be at most 100')
+    .optional(),
+});
+
+export type PaginationRequest = z.infer<typeof PaginationRequestSchema>;
+
+/**
+ * Cursor pagination metadata returned with list endpoints.
+ */
+export const PaginationResponseSchema = z.object({
+  next_cursor: z.string().nullable(),
+  has_more: z.boolean(),
+  total: z.number().int().nonnegative().optional(),
+});
+
+export type PaginationResponse = z.infer<typeof PaginationResponseSchema>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -8,6 +8,7 @@ export * from './auth';
 export * from './billing';
 export * from './bookings';
 export * from './chat';
+export * from './common';
 export * from './health';
 export * from './locale';
 export * from './membership';


### PR DESCRIPTION
## Summary
Adds `packages/contracts` **common** foundations per #57:
- Pagination request/response Zod schemas
- `LocaleCodeSchema`, `LocalePreferenceSchema`
- `ApiErrorResponseSchema`
- Barrel export from root `@myclup/contracts`

Closes #57

Made with [Cursor](https://cursor.com)