### PR TITLE
feat(api-client): errors, fetcher, and HTTP helpers (#58)

### DIFF
--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -77,15 +77,16 @@ const ping = await api.health.ping();
 
 ## Error Handling
 
-- **Non-2xx response**: Throws `ApiError` with `status` and `body`
+- **Non-2xx response**: Throws `ApiError` with `status`, optional `code` / `details` (when body matches `ApiErrorResponseSchema` from `@myclup/contracts`), and raw `body` when available
 - **Invalid response shape**: Throws `ZodError` from `contract.response.parse()`
+- **`parseApiError(response)`** / **`fetcher()`**: Low-level helpers for custom calls
 
 ```typescript
 try {
   await api.health.ping();
 } catch (err) {
   if (err instanceof ApiError) {
-    console.error(err.status, err.body);
+    console.error(err.status, err.code, err.body);
   }
   throw err;
 }

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -1,4 +1,5 @@
 import type { z } from 'zod';
+import { parseApiError, ApiError } from './errors';
 
 /** Contract shape: path, method, optional request schema, response schema. */
 export type ApiContract<TRequest = unknown, TResponse = unknown> = {
@@ -15,23 +16,13 @@ export type ApiClientConfig = {
   /** Optional static headers to inject. Applied to every request. */
   headers?: Record<string, string>;
   /**
+   * Default `Accept-Language` when a request does not pass an explicit `locale`
+   * in {@link RequestOptions}.
+   */
+  defaultLocale?: string;
+  /**
    * Optional async function that returns auth headers for each request.
    * Use this for dynamic token injection (Supabase session on web, access_token on mobile).
-   *
-   * Web example:
-   *   getAuthHeaders: async () => {
-   *     const { data } = await supabase.auth.getSession();
-   *     const token = data.session?.access_token;
-   *     return token ? { Authorization: `Bearer ${token}` } : {};
-   *   }
-   *
-   * Mobile example:
-   *   getAuthHeaders: async () => {
-   *     const session = await getLocalSession();
-   *     return session?.access_token
-   *       ? { Authorization: `Bearer ${session.access_token}` }
-   *       : {};
-   *   }
    */
   getAuthHeaders?: () => Promise<Record<string, string>> | Record<string, string>;
   /** Custom fetch implementation (for testing or custom behavior). */
@@ -44,19 +35,11 @@ export type RequestOptions = {
   pathParams?: Record<string, string>;
   /** Append as query string for GET (e.g. { gymId: "xxx", locale: "tr" }). */
   queryParams?: Record<string, string | number | boolean | undefined>;
+  /** Overrides {@link ApiClientConfig.defaultLocale} for this request's `Accept-Language`. */
+  locale?: string;
 };
 
-/** Thrown when the API returns a non-2xx status or response fails validation. */
-export class ApiError extends Error {
-  constructor(
-    message: string,
-    public readonly status?: number,
-    public readonly body?: string
-  ) {
-    super(message);
-    this.name = 'ApiError';
-  }
-}
+export { ApiError };
 
 /**
  * Creates an API client with configurable base URL and optional auth headers.
@@ -67,20 +50,29 @@ export function createApiClient(config: ApiClientConfig) {
   const staticHeaders = config.headers ?? {};
   const doFetch = config.fetch ?? fetch;
 
+  async function buildHeaders(localeOverride?: string): Promise<Record<string, string>> {
+    const authHeaders = config.getAuthHeaders ? await config.getAuthHeaders() : {};
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...staticHeaders,
+      ...authHeaders,
+    };
+    const locale = localeOverride ?? config.defaultLocale;
+    if (locale) {
+      headers['Accept-Language'] = locale;
+    }
+    return headers;
+  }
+
   /**
    * Performs a contract-based request. Fetches the endpoint, parses the response
    * with contract.response.parse(), and returns the typed result.
-   *
-   * Path params: Pass options.pathParams to substitute :paramName in the path.
-   * Query params: Pass options.queryParams for GET requests (e.g. templates, quick-replies).
-   * GET with requestData: When requestData is a plain object, it is serialized as query string.
    */
   async function request<T>(
     contract: ApiContract<unknown, T>,
     requestData?: unknown,
     options?: RequestOptions
   ): Promise<T> {
-    const authHeaders = config.getAuthHeaders ? await config.getAuthHeaders() : {};
     let path = contract.path;
     if (options?.pathParams) {
       for (const [key, value] of Object.entries(options.pathParams)) {
@@ -96,9 +88,11 @@ export function createApiClient(config: ApiClientConfig) {
       const qs = search.toString();
       if (qs) url += `?${qs}`;
     }
+
+    const headers = await buildHeaders(options?.locale);
     const init: RequestInit = {
       method: contract.method,
-      headers: { 'Content-Type': 'application/json', ...staticHeaders, ...authHeaders },
+      headers,
     };
 
     if (requestData !== undefined) {
@@ -113,7 +107,7 @@ export function createApiClient(config: ApiClientConfig) {
           }
         }
         const query = params.toString();
-        if (query) url += `?${query}`;
+        if (query) url += `${url.includes('?') ? '&' : '?'}${query}`;
       } else {
         init.body = JSON.stringify(requestData);
       }
@@ -122,13 +116,73 @@ export function createApiClient(config: ApiClientConfig) {
     const res = await doFetch(url, init);
 
     if (!res.ok) {
-      const body = await res.text();
-      throw new ApiError(`API request failed: ${res.status} ${res.statusText}`, res.status, body);
+      throw await parseApiError(res);
     }
 
     const json = await res.json();
     return contract.response.parse(json) as T;
   }
 
-  return { request };
+  type MethodInit = Omit<RequestInit, 'headers' | 'method'> & { locale?: string };
+
+  async function get<T>(path: string, init?: MethodInit): Promise<T> {
+    const { locale, ...rest } = init ?? {};
+    const headers = await buildHeaders(locale);
+    const res = await doFetch(`${baseUrl}${path}`, { ...rest, method: 'GET', headers });
+    if (!res.ok) throw await parseApiError(res);
+    return res.json() as Promise<T>;
+  }
+
+  async function post<T>(path: string, body?: unknown, init?: MethodInit): Promise<T> {
+    const { locale, ...rest } = init ?? {};
+    const headers = await buildHeaders(locale);
+    const res = await doFetch(`${baseUrl}${path}`, {
+      ...rest,
+      method: 'POST',
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+    if (!res.ok) throw await parseApiError(res);
+    return res.json() as Promise<T>;
+  }
+
+  async function put<T>(path: string, body?: unknown, init?: MethodInit): Promise<T> {
+    const { locale, ...rest } = init ?? {};
+    const headers = await buildHeaders(locale);
+    const res = await doFetch(`${baseUrl}${path}`, {
+      ...rest,
+      method: 'PUT',
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+    if (!res.ok) throw await parseApiError(res);
+    return res.json() as Promise<T>;
+  }
+
+  async function patch<T>(path: string, body?: unknown, init?: MethodInit): Promise<T> {
+    const { locale, ...rest } = init ?? {};
+    const headers = await buildHeaders(locale);
+    const res = await doFetch(`${baseUrl}${path}`, {
+      ...rest,
+      method: 'PATCH',
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+    if (!res.ok) throw await parseApiError(res);
+    return res.json() as Promise<T>;
+  }
+
+  async function del<T>(path: string, init?: MethodInit): Promise<T> {
+    const { locale, ...rest } = init ?? {};
+    const headers = await buildHeaders(locale);
+    const res = await doFetch(`${baseUrl}${path}`, {
+      ...rest,
+      method: 'DELETE',
+      headers,
+    });
+    if (!res.ok) throw await parseApiError(res);
+    return res.json() as Promise<T>;
+  }
+
+  return { request, get, post, put, patch, delete: del };
 }

--- a/packages/api-client/src/errors.test.ts
+++ b/packages/api-client/src/errors.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { ApiError, parseApiError } from './errors';
+
+describe('parseApiError', () => {
+  it('returns ApiError with code and details when body matches schema', async () => {
+    const res = {
+      status: 400,
+      statusText: 'Bad Request',
+      text: () =>
+        Promise.resolve(
+          JSON.stringify({ code: 'VALIDATION', message: 'Invalid input', details: { x: 1 } })
+        ),
+    } as Response;
+
+    const err = await parseApiError(res);
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.message).toBe('Invalid input');
+    expect(err.status).toBe(400);
+    expect(err.code).toBe('VALIDATION');
+    expect(err.details).toEqual({ x: 1 });
+    expect(err.body).toContain('VALIDATION');
+  });
+
+  it('returns generic ApiError when JSON does not match schema', async () => {
+    const res = {
+      status: 502,
+      statusText: 'Bad Gateway',
+      text: () => Promise.resolve(JSON.stringify({ foo: 'bar' })),
+    } as Response;
+
+    const err = await parseApiError(res);
+    expect(err.code).toBe('UNKNOWN');
+    expect(err.status).toBe(502);
+  });
+
+  it('handles empty body without throwing', async () => {
+    const res = {
+      status: 500,
+      statusText: 'Internal Server Error',
+      text: () => Promise.resolve(''),
+    } as Response;
+
+    const err = await parseApiError(res);
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(500);
+  });
+});

--- a/packages/api-client/src/errors.ts
+++ b/packages/api-client/src/errors.ts
@@ -1,0 +1,64 @@
+import { ApiErrorResponseSchema } from '@myclup/contracts';
+
+/**
+ * Typed API failure. `code` / `details` are set when the response body matches {@link ApiErrorResponseSchema}.
+ */
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status?: number,
+    public readonly code?: string,
+    public readonly details?: unknown,
+    /** Raw response body (when available) for debugging or non-JSON errors */
+    public readonly body?: string
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+/**
+ * Parse a failed `Response` into an `ApiError`.
+ * Uses `ApiErrorResponseSchema.safeParse` on JSON bodies; falls back to a generic error.
+ */
+export async function parseApiError(response: Response): Promise<ApiError> {
+  const status = response.status;
+  const statusText = response.statusText;
+  let text = '';
+  try {
+    text = await response.text();
+  } catch {
+    return new ApiError(`API request failed: ${status} ${statusText}`, status, 'HTTP_ERROR');
+  }
+
+  if (!text.trim()) {
+    return new ApiError(statusText || 'Request failed', status, 'HTTP_ERROR', undefined, text);
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    return new ApiError(
+      `API request failed: ${status} ${statusText}`,
+      status,
+      'HTTP_ERROR',
+      undefined,
+      text
+    );
+  }
+
+  const parsed = ApiErrorResponseSchema.safeParse(json);
+  if (parsed.success) {
+    const { code, message, details } = parsed.data;
+    return new ApiError(message, status, code, details, text);
+  }
+
+  return new ApiError(
+    `API request failed: ${status} ${statusText}`,
+    status,
+    'UNKNOWN',
+    undefined,
+    text
+  );
+}

--- a/packages/api-client/src/fetcher.test.ts
+++ b/packages/api-client/src/fetcher.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetcher } from './fetcher';
+import { ApiError } from './errors';
+
+describe('fetcher', () => {
+  it('returns parsed JSON on 2xx', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ a: 1 }),
+    });
+
+    const data = await fetcher<{ a: number }>('https://x.test/data', {}, mockFetch);
+    expect(data).toEqual({ a: 1 });
+  });
+
+  it('sets Content-Type application/json by default', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    });
+
+    await fetcher('https://x.test/', { method: 'POST', body: '{}' }, mockFetch);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://x.test/',
+      expect.objectContaining({
+        headers: expect.any(Headers),
+      })
+    );
+    const headers = mockFetch.mock.calls[0][1].headers as Headers;
+    expect(headers.get('Content-Type')).toContain('application/json');
+  });
+
+  it('sets Accept-Language when locale provided', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    });
+
+    await fetcher('https://x.test/', { locale: 'tr' }, mockFetch);
+    const headers = mockFetch.mock.calls[0][1].headers as Headers;
+    expect(headers.get('Accept-Language')).toBe('tr');
+  });
+
+  it('does not set Accept-Language when locale omitted', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    });
+
+    await fetcher('https://x.test/', {}, mockFetch);
+    const headers = mockFetch.mock.calls[0][1].headers as Headers;
+    expect(headers.get('Accept-Language')).toBeNull();
+  });
+
+  it('throws ApiError on non-2xx', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      text: () => Promise.resolve(''),
+    });
+
+    await expect(fetcher('https://x.test/missing', {}, mockFetch)).rejects.toBeInstanceOf(ApiError);
+  });
+});

--- a/packages/api-client/src/fetcher.ts
+++ b/packages/api-client/src/fetcher.ts
@@ -1,0 +1,41 @@
+import { parseApiError } from './errors';
+
+export type FetcherOptions = RequestInit & {
+  /** Sets `Accept-Language` when provided */
+  locale?: string;
+};
+
+/**
+ * Low-level JSON fetch helper: default `Content-Type: application/json`,
+ * optional `Accept-Language`, throws {@link ApiError} from {@link parseApiError} on non-2xx.
+ */
+export async function fetcher<T>(
+  url: string,
+  options: FetcherOptions = {},
+  fetchImpl: typeof fetch = fetch
+): Promise<T> {
+  const { locale, headers, ...rest } = options;
+  const merged = new Headers(headers);
+
+  if (!merged.has('Content-Type')) {
+    merged.set('Content-Type', 'application/json');
+  }
+  if (locale) {
+    merged.set('Accept-Language', locale);
+  }
+
+  const res = await fetchImpl(url, {
+    ...rest,
+    headers: merged,
+  });
+
+  if (!res.ok) {
+    throw await parseApiError(res);
+  }
+
+  if (res.status === 204) {
+    return undefined as T;
+  }
+
+  return res.json() as Promise<T>;
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -22,6 +22,8 @@ export {
   type ApiContract,
   type RequestOptions,
 } from './client';
+export { parseApiError } from './errors';
+export { fetcher, type FetcherOptions } from './fetcher';
 export { createHealthApi } from './health';
 export { createAuthApi } from './auth';
 export { createChatApi } from './chat';


### PR DESCRIPTION
## Summary
- `errors.ts`: `parseApiError`, `ApiError` with `code`/`details` from `ApiErrorResponseSchema`
- `fetcher.ts`: JSON fetch + `Accept-Language`
- `createApiClient`: `defaultLocale`, per-request `locale`, `get`/`post`/`put`/`patch`/`delete`

Closes #58

Made with [Cursor](https://cursor.com)