### PR TITLE
feat(epic-18): membership & billing shells + staff member workspace (#123 #124)

### DIFF
--- a/apps/mobile-admin/app/index.tsx
+++ b/apps/mobile-admin/app/index.tsx
@@ -41,6 +41,18 @@ export default function HomeScreen() {
           </View>
         </Card>
 
+        <Card>
+          <SectionHeader
+            title={t('membership:gymAdmin.staff.title')}
+            subtitle={t('membership:gymAdmin.staff.subtitle')}
+          />
+          <View style={styles.buttonRow}>
+            <Button variant="secondary" onPress={() => router.push('/members')}>
+              {t('membership:gymAdmin.staff.openAction')}
+            </Button>
+          </View>
+        </Card>
+
         <LanguageSwitcher onLanguageChange={changeLanguageAndPersist} />
       </View>
     </ScreenContainer>

--- a/apps/mobile-admin/app/members/_layout.tsx
+++ b/apps/mobile-admin/app/members/_layout.tsx
@@ -1,0 +1,17 @@
+import { Stack } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+
+export default function MembersLayout() {
+  const { t } = useTranslation('membership');
+
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: true,
+        headerTitle: t('gymAdmin.staff.title'),
+      }}
+    >
+      <Stack.Screen name="index" options={{ title: t('gymAdmin.staff.title') }} />
+    </Stack>
+  );
+}

--- a/apps/mobile-admin/app/members/index.tsx
+++ b/apps/mobile-admin/app/members/index.tsx
@@ -1,0 +1,34 @@
+import { useTranslation } from 'react-i18next';
+import { View, Text, StyleSheet } from 'react-native';
+import { ScreenContainer, Card, SectionHeader } from '@myclup/ui-native';
+
+export default function MembersWorkspaceScreen() {
+  const { t } = useTranslation('membership');
+
+  return (
+    <ScreenContainer>
+      <View style={styles.container}>
+        <Card>
+          <SectionHeader
+            title={t('gymAdmin.staff.title')}
+            subtitle={t('gymAdmin.staff.subtitle')}
+          />
+          <Text style={styles.placeholder}>{t('gymAdmin.staff.placeholder')}</Text>
+        </Card>
+      </View>
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    gap: 16,
+  },
+  placeholder: {
+    marginTop: 12,
+    color: '#64748b',
+    fontSize: 15,
+    lineHeight: 22,
+  },
+});

--- a/apps/web-gym-admin/app/[locale]/billing/page.tsx
+++ b/apps/web-gym-admin/app/[locale]/billing/page.tsx
@@ -1,0 +1,38 @@
+import { setRequestLocale, getTranslations } from 'next-intl/server';
+import { Link } from '@/src/i18n/navigation';
+
+type Props = {
+  params: Promise<{ locale: string }>;
+};
+
+export default async function BillingPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  const t = await getTranslations('membership');
+  const tCommon = await getTranslations('common');
+
+  return (
+    <main style={{ padding: '1.5rem', fontFamily: 'sans-serif', maxWidth: 960, margin: '0 auto' }}>
+      <p style={{ marginBottom: '0.75rem' }}>
+        <Link href="/" style={{ color: '#0f766e', textDecoration: 'none', fontWeight: 600 }}>
+          {tCommon('button.back')} · {tCommon('adminShell.home')}
+        </Link>
+      </p>
+      <h1 style={{ margin: '0 0 0.5rem', fontSize: '1.75rem' }}>{t('gymAdmin.billing.title')}</h1>
+      <p style={{ margin: '0 0 1.25rem', color: '#475569' }}>{t('gymAdmin.billing.subtitle')}</p>
+      <section
+        style={{
+          padding: '1.25rem',
+          borderRadius: 16,
+          border: '1px solid #e2e8f0',
+          background: '#f8fafc',
+        }}
+      >
+        <div style={{ fontWeight: 700, marginBottom: '0.5rem' }}>
+          {t('gymAdmin.billing.cardTitle')}
+        </div>
+        <p style={{ margin: 0, color: '#64748b' }}>{t('gymAdmin.billing.placeholder')}</p>
+      </section>
+    </main>
+  );
+}

--- a/apps/web-gym-admin/app/[locale]/membership-plans/page.tsx
+++ b/apps/web-gym-admin/app/[locale]/membership-plans/page.tsx
@@ -1,0 +1,38 @@
+import { setRequestLocale, getTranslations } from 'next-intl/server';
+import { Link } from '@/src/i18n/navigation';
+
+type Props = {
+  params: Promise<{ locale: string }>;
+};
+
+export default async function MembershipPlansPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  const t = await getTranslations('membership');
+  const tCommon = await getTranslations('common');
+
+  return (
+    <main style={{ padding: '1.5rem', fontFamily: 'sans-serif', maxWidth: 960, margin: '0 auto' }}>
+      <p style={{ marginBottom: '0.75rem' }}>
+        <Link href="/" style={{ color: '#0f766e', textDecoration: 'none', fontWeight: 600 }}>
+          {tCommon('button.back')} · {tCommon('adminShell.home')}
+        </Link>
+      </p>
+      <h1 style={{ margin: '0 0 0.5rem', fontSize: '1.75rem' }}>{t('gymAdmin.plans.title')}</h1>
+      <p style={{ margin: '0 0 1.25rem', color: '#475569' }}>{t('gymAdmin.plans.subtitle')}</p>
+      <section
+        style={{
+          padding: '1.25rem',
+          borderRadius: 16,
+          border: '1px solid #e2e8f0',
+          background: '#f8fafc',
+        }}
+      >
+        <div style={{ fontWeight: 700, marginBottom: '0.5rem' }}>
+          {t('gymAdmin.plans.cardTitle')}
+        </div>
+        <p style={{ margin: 0, color: '#64748b' }}>{t('gymAdmin.plans.placeholder')}</p>
+      </section>
+    </main>
+  );
+}

--- a/apps/web-gym-admin/app/[locale]/page.tsx
+++ b/apps/web-gym-admin/app/[locale]/page.tsx
@@ -10,6 +10,7 @@ export default async function HomePage({ params }: Props) {
   setRequestLocale(locale);
 
   const t = await getTranslations('common');
+  const tm = await getTranslations('membership');
   const cardStyle = {
     padding: '1.25rem',
     borderRadius: 20,
@@ -73,6 +74,36 @@ export default async function HomePage({ params }: Props) {
           >
             <div style={{ fontSize: '1.15rem', fontWeight: 700 }}>{t('adminShell.chat')}</div>
             <p style={{ margin: '0.4rem 0 0', color: '#475569' }}>{t('adminShell.chatSubtitle')}</p>
+          </Link>
+
+          <Link
+            href="/membership-plans"
+            style={{
+              ...cardStyle,
+              border: '1px solid #dbe4ee',
+              background: '#ffffff',
+            }}
+          >
+            <div style={{ fontSize: '1.15rem', fontWeight: 700 }}>{tm('gymAdmin.plans.title')}</div>
+            <p style={{ margin: '0.4rem 0 0', color: '#475569' }}>
+              {tm('gymAdmin.plans.subtitle')}
+            </p>
+          </Link>
+
+          <Link
+            href="/billing"
+            style={{
+              ...cardStyle,
+              border: '1px solid #dbe4ee',
+              background: '#ffffff',
+            }}
+          >
+            <div style={{ fontSize: '1.15rem', fontWeight: 700 }}>
+              {tm('gymAdmin.billing.title')}
+            </div>
+            <p style={{ margin: '0.4rem 0 0', color: '#475569' }}>
+              {tm('gymAdmin.billing.subtitle')}
+            </p>
           </Link>
 
           {process.env.NODE_ENV === 'development' ? (

--- a/packages/i18n/src/__tests__/membership-gym-admin-keys.test.ts
+++ b/packages/i18n/src/__tests__/membership-gym-admin-keys.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import membershipEn from '../namespaces/membership/en.json';
+import membershipTr from '../namespaces/membership/tr.json';
+
+function flattenKeys(value: Record<string, unknown>, prefix = ''): string[] {
+  return Object.entries(value).flatMap(([key, nested]) => {
+    const current = prefix ? `${prefix}.${key}` : key;
+    if (nested && typeof nested === 'object' && !Array.isArray(nested)) {
+      return flattenKeys(nested as Record<string, unknown>, current);
+    }
+    return [current];
+  });
+}
+
+describe('membership gymAdmin keys', () => {
+  it('keeps gymAdmin branch in parity across locales', () => {
+    const branch = 'gymAdmin';
+    const enKeys = flattenKeys({
+      [branch]: membershipEn[branch as keyof typeof membershipEn],
+    } as Record<string, unknown>);
+    const trKeys = flattenKeys({
+      [branch]: membershipTr[branch as keyof typeof membershipTr],
+    } as Record<string, unknown>);
+    expect(trKeys).toEqual(enKeys);
+  });
+});

--- a/packages/i18n/src/namespaces/membership/en.json
+++ b/packages/i18n/src/namespaces/membership/en.json
@@ -112,5 +112,25 @@
       "void": "Void",
       "overdue": "Overdue"
     }
+  },
+  "gymAdmin": {
+    "plans": {
+      "title": "Membership plans",
+      "subtitle": "Create and manage packages your members can purchase.",
+      "placeholder": "Plan builder and BFF-backed lists will appear here as the Epic #18 rollout continues.",
+      "cardTitle": "Plans workspace"
+    },
+    "billing": {
+      "title": "Billing & finance",
+      "subtitle": "Invoices, payments, receivables, and discounts in one place.",
+      "placeholder": "Finance dashboards and workflows will connect to the billing APIs in follow-up tasks.",
+      "cardTitle": "Finance workspace"
+    },
+    "staff": {
+      "title": "Member operations",
+      "subtitle": "Search members, validate access, and run lifecycle actions from the front desk.",
+      "placeholder": "Member list, detail, and QR validation will use the membership BFF endpoints.",
+      "openAction": "Open member workspace"
+    }
   }
 }

--- a/packages/i18n/src/namespaces/membership/tr.json
+++ b/packages/i18n/src/namespaces/membership/tr.json
@@ -112,5 +112,25 @@
       "void": "Gecersiz",
       "overdue": "Gecikti"
     }
+  },
+  "gymAdmin": {
+    "plans": {
+      "title": "Uyelik planlari",
+      "subtitle": "Uyelerin satin alabilecegi paketleri olusturun ve yonetin.",
+      "placeholder": "Plan olusturucu ve BFF destekli listeler Epic #18 ilerledikce burada gorunecek.",
+      "cardTitle": "Planlar calisma alani"
+    },
+    "billing": {
+      "title": "Faturalama ve finans",
+      "subtitle": "Faturalar, odemeler, alacaklar ve indirimler tek yerde.",
+      "placeholder": "Finans panelleri ve akislari sonraki gorevlerde faturalama API'lerine baglanacak.",
+      "cardTitle": "Finans calisma alani"
+    },
+    "staff": {
+      "title": "Uye islemleri",
+      "subtitle": "Uyeleri arayin, erisimi dogrulayin ve resepsiyondan yasam dongusu aksiyonlarini calistirin.",
+      "placeholder": "Uye listesi, detay ve QR dogrulama uyelik BFF uclarina baglanacak.",
+      "openAction": "Uye calisma alanini ac"
+    }
   }
 }


### PR DESCRIPTION
## Summary
Foundational **localized** surfaces for Epic #18:
- **#123** Web gym admin: `/membership-plans`, `/billing`, home cards
- **#124** Mobile admin: `/members` stack + home entry

Shared copy in `membership.gymAdmin.*` (en/tr).

Closes #123
Closes #124

Made with [Cursor](https://cursor.com)