### PR TITLE
feat(mobile-user): Epic #30 booking, discovery, progress surfaces

### DIFF
--- a/apps/mobile-user/app/booking/_layout.tsx
+++ b/apps/mobile-user/app/booking/_layout.tsx
@@ -1,0 +1,17 @@
+import { Stack } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+
+export default function BookingLayout() {
+  const { t } = useTranslation('common');
+
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: true,
+        headerTitle: t('memberBooking.title'),
+      }}
+    >
+      <Stack.Screen name="index" options={{ title: t('memberBooking.title') }} />
+    </Stack>
+  );
+}

--- a/apps/mobile-user/app/booking/index.tsx
+++ b/apps/mobile-user/app/booking/index.tsx
@@ -1,0 +1,95 @@
+import { FlatList, RefreshControl, StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { formatDate, formatTime } from '@myclup/utils';
+import { Card, ScreenContainer } from '@myclup/ui-native';
+import type { BookingSession } from '@myclup/contracts/bookings';
+import { useBookingSessions } from '../../src/features/booking/useBookingSessions';
+import { AppStateBlock } from '../../src/components/AppStateBlock';
+import { AppText } from '../../src/components/AppText';
+import { appTheme } from '../../src/theme/appTheme';
+
+export default function BookingScheduleScreen() {
+  const { t } = useTranslation('common');
+  const { sessions, loading, error, refresh, locale } = useBookingSessions();
+
+  const renderItem = ({ item }: { item: BookingSession }) => (
+    <Card style={styles.sessionCard}>
+      <AppText variant="subtitle" style={styles.sessionTitle}>
+        {item.title}
+      </AppText>
+      <AppText variant="caption" tone="muted">
+        {formatDate(new Date(item.startsAt), locale)} ·{' '}
+        {formatTime(new Date(item.startsAt), locale)} — {formatTime(new Date(item.endsAt), locale)}
+      </AppText>
+      {item.locationLabel ? (
+        <AppText variant="caption" tone="muted" style={styles.meta}>
+          {item.locationLabel}
+        </AppText>
+      ) : null}
+    </Card>
+  );
+
+  return (
+    <ScreenContainer style={styles.screen}>
+      <View style={styles.header}>
+        <AppText variant="title">{t('memberBooking.title')}</AppText>
+        <AppText variant="subtitle" tone="muted" style={styles.subtitle}>
+          {t('memberBooking.subtitle')}
+        </AppText>
+      </View>
+      {loading && sessions.length === 0 ? (
+        <AppStateBlock
+          loading
+          title={t('memberBooking.loadingTitle')}
+          description={t('memberBooking.loadingBody')}
+        />
+      ) : null}
+      {error && !loading ? (
+        <AppStateBlock
+          title={t('memberBooking.errorTitle')}
+          description={t('memberBooking.errorBody')}
+        />
+      ) : null}
+      {!loading && !error && sessions.length === 0 ? (
+        <AppStateBlock
+          title={t('memberBooking.emptyTitle')}
+          description={t('memberBooking.emptyBody')}
+        />
+      ) : null}
+      <FlatList
+        data={sessions}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        contentContainerStyle={styles.list}
+        refreshControl={<RefreshControl refreshing={loading} onRefresh={() => void refresh()} />}
+      />
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+  },
+  header: {
+    paddingHorizontal: appTheme.spacing.md,
+    paddingBottom: appTheme.spacing.sm,
+    gap: 4,
+  },
+  subtitle: {
+    marginTop: 4,
+  },
+  list: {
+    padding: appTheme.spacing.md,
+    gap: 12,
+  },
+  sessionCard: {
+    marginBottom: 8,
+  },
+  sessionTitle: {
+    marginBottom: 4,
+  },
+  meta: {
+    marginTop: 4,
+  },
+});

--- a/apps/mobile-user/app/discovery/_layout.tsx
+++ b/apps/mobile-user/app/discovery/_layout.tsx
@@ -1,0 +1,17 @@
+import { Stack } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+
+export default function DiscoveryLayout() {
+  const { t } = useTranslation('common');
+
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: true,
+        headerTitle: t('memberDiscovery.title'),
+      }}
+    >
+      <Stack.Screen name="index" options={{ title: t('memberDiscovery.title') }} />
+    </Stack>
+  );
+}

--- a/apps/mobile-user/app/discovery/index.tsx
+++ b/apps/mobile-user/app/discovery/index.tsx
@@ -1,0 +1,42 @@
+import { StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Card, ScreenContainer } from '@myclup/ui-native';
+import { AppText } from '../../src/components/AppText';
+import { appTheme } from '../../src/theme/appTheme';
+
+export default function DiscoveryScreen() {
+  const { t } = useTranslation('common');
+
+  return (
+    <ScreenContainer style={styles.screen}>
+      <View style={styles.header}>
+        <AppText variant="title">{t('memberDiscovery.title')}</AppText>
+        <AppText variant="subtitle" tone="muted" style={styles.subtitle}>
+          {t('memberDiscovery.subtitle')}
+        </AppText>
+      </View>
+      <Card style={styles.card}>
+        <AppText variant="body" tone="muted">
+          {t('memberDiscovery.body')}
+        </AppText>
+      </Card>
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+  },
+  header: {
+    paddingHorizontal: appTheme.spacing.md,
+    paddingBottom: appTheme.spacing.sm,
+    gap: 4,
+  },
+  subtitle: {
+    marginTop: 4,
+  },
+  card: {
+    marginHorizontal: appTheme.spacing.md,
+  },
+});

--- a/apps/mobile-user/app/progress/_layout.tsx
+++ b/apps/mobile-user/app/progress/_layout.tsx
@@ -1,0 +1,17 @@
+import { Stack } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+
+export default function ProgressLayout() {
+  const { t } = useTranslation('common');
+
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: true,
+        headerTitle: t('memberProgress.title'),
+      }}
+    >
+      <Stack.Screen name="index" options={{ title: t('memberProgress.title') }} />
+    </Stack>
+  );
+}

--- a/apps/mobile-user/app/progress/index.tsx
+++ b/apps/mobile-user/app/progress/index.tsx
@@ -1,0 +1,42 @@
+import { StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Card, ScreenContainer } from '@myclup/ui-native';
+import { AppText } from '../../src/components/AppText';
+import { appTheme } from '../../src/theme/appTheme';
+
+export default function ProgressScreen() {
+  const { t } = useTranslation('common');
+
+  return (
+    <ScreenContainer style={styles.screen}>
+      <View style={styles.header}>
+        <AppText variant="title">{t('memberProgress.title')}</AppText>
+        <AppText variant="subtitle" tone="muted" style={styles.subtitle}>
+          {t('memberProgress.subtitle')}
+        </AppText>
+      </View>
+      <Card style={styles.card}>
+        <AppText variant="body" tone="muted">
+          {t('memberProgress.body')}
+        </AppText>
+      </Card>
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+  },
+  header: {
+    paddingHorizontal: appTheme.spacing.md,
+    paddingBottom: appTheme.spacing.sm,
+    gap: 4,
+  },
+  subtitle: {
+    marginTop: 4,
+  },
+  card: {
+    marginHorizontal: appTheme.spacing.md,
+  },
+});

--- a/apps/mobile-user/src/features/booking/useBookingSessions.ts
+++ b/apps/mobile-user/src/features/booking/useBookingSessions.ts
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { BookingSession } from '@myclup/contracts/bookings';
+import { api } from '../../lib/api';
+import { resolveSupportedLocale } from '../membership/helpers';
+
+export function useBookingSessions() {
+  const { i18n } = useTranslation('common');
+  const locale = useMemo(
+    () => resolveSupportedLocale(i18n.resolvedLanguage),
+    [i18n.resolvedLanguage]
+  );
+  const [sessions, setSessions] = useState<BookingSession[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await api.bookings.listSessions({ limit: 30 });
+      setSessions(res.items);
+    } catch (e) {
+      setError(e instanceof Error ? e : new Error('bookings_load_failed'));
+      setSessions([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return { sessions, loading, error, refresh: load, locale };
+}

--- a/apps/mobile-user/src/features/home/homeDashboard.test.ts
+++ b/apps/mobile-user/src/features/home/homeDashboard.test.ts
@@ -15,12 +15,13 @@ describe('home dashboard helpers', () => {
     expect(getConversationTitleKey('direct')).toBe('conversation.direct');
   });
 
-  it('builds the expected quick actions with booking disabled and renew wired', () => {
+  it('builds the expected quick actions with booking, chat, renew, discovery, and progress', () => {
     const quickActions = buildQuickActions();
-    expect(quickActions).toHaveLength(4);
+    expect(quickActions).toHaveLength(6);
     expect(quickActions[0]).toMatchObject({
       key: 'bookClass',
-      disabled: true,
+      disabled: false,
+      route: '/booking',
       labelKey: 'quickActions.bookClass',
       hintKey: 'quickActions.bookClassHint',
     });
@@ -32,15 +33,13 @@ describe('home dashboard helpers', () => {
       key: 'renewMembership',
       route: '/membership/renew',
     });
-  });
-
-  it('keeps booking out of route wiring until scheduling is implemented', () => {
-    const quickActions = buildQuickActions();
-
-    expect(quickActions[0]).toMatchObject({
-      key: 'bookClass',
-      disabled: true,
+    expect(quickActions[4]).toMatchObject({
+      key: 'discoverGyms',
+      route: '/discovery',
     });
-    expect(quickActions[0]?.route).toBeUndefined();
+    expect(quickActions[5]).toMatchObject({
+      key: 'trackProgress',
+      route: '/progress',
+    });
   });
 });

--- a/apps/mobile-user/src/features/home/homeDashboard.ts
+++ b/apps/mobile-user/src/features/home/homeDashboard.ts
@@ -1,6 +1,12 @@
 export type MembershipTone = 'primary' | 'success' | 'warning' | 'danger' | 'neutral';
 
-export type QuickActionKey = 'bookClass' | 'openChat' | 'showQr' | 'renewMembership';
+export type QuickActionKey =
+  | 'bookClass'
+  | 'openChat'
+  | 'showQr'
+  | 'renewMembership'
+  | 'discoverGyms'
+  | 'trackProgress';
 
 export type QuickActionConfig = {
   key: QuickActionKey;
@@ -9,14 +15,25 @@ export type QuickActionConfig = {
     | 'quickActions.bookClass'
     | 'quickActions.openChat'
     | 'quickActions.showQr'
-    | 'quickActions.renewMembership';
+    | 'quickActions.renewMembership'
+    | 'quickActions.discoverGyms'
+    | 'quickActions.trackProgress';
   hintKey:
     | 'quickActions.bookClassHint'
     | 'quickActions.openChatHint'
     | 'quickActions.showQrHint'
-    | 'quickActions.renewMembershipHint';
+    | 'quickActions.renewMembershipHint'
+    | 'quickActions.discoverGymsHint'
+    | 'quickActions.trackProgressHint';
   disabled: boolean;
-  route?: '/' | '/chat' | '/membership' | '/membership/renew';
+  route?:
+    | '/'
+    | '/booking'
+    | '/chat'
+    | '/membership'
+    | '/membership/renew'
+    | '/discovery'
+    | '/progress';
 };
 
 export function getMembershipTone(status: string): MembershipTone {
@@ -52,7 +69,8 @@ export function buildQuickActions(): QuickActionConfig[] {
       icon: 'calendar-plus-outline',
       labelKey: 'quickActions.bookClass',
       hintKey: 'quickActions.bookClassHint',
-      disabled: true,
+      disabled: false,
+      route: '/booking',
     },
     {
       key: 'openChat',
@@ -77,6 +95,22 @@ export function buildQuickActions(): QuickActionConfig[] {
       hintKey: 'quickActions.renewMembershipHint',
       disabled: false,
       route: '/membership/renew',
+    },
+    {
+      key: 'discoverGyms',
+      icon: 'map-search-outline',
+      labelKey: 'quickActions.discoverGyms',
+      hintKey: 'quickActions.discoverGymsHint',
+      disabled: false,
+      route: '/discovery',
+    },
+    {
+      key: 'trackProgress',
+      icon: 'chart-timeline-variant',
+      labelKey: 'quickActions.trackProgress',
+      hintKey: 'quickActions.trackProgressHint',
+      disabled: false,
+      route: '/progress',
     },
   ];
 }

--- a/packages/i18n/src/__tests__/common-member-booking-keys.test.ts
+++ b/packages/i18n/src/__tests__/common-member-booking-keys.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import commonEn from '../namespaces/common/en.json';
+import commonTr from '../namespaces/common/tr.json';
+
+function flattenKeys(value: Record<string, unknown>, prefix = ''): string[] {
+  return Object.entries(value).flatMap(([key, nested]) => {
+    const current = prefix ? `${prefix}.${key}` : key;
+    if (nested && typeof nested === 'object' && !Array.isArray(nested)) {
+      return flattenKeys(nested as Record<string, unknown>, current);
+    }
+    return [current];
+  });
+}
+
+describe('common member surface keys', () => {
+  it.each(['memberBooking', 'memberDiscovery', 'memberProgress'] as const)(
+    'keeps %s branch in parity across locales',
+    (branch) => {
+      const enKeys = flattenKeys({ [branch]: commonEn[branch as keyof typeof commonEn] } as Record<
+        string,
+        unknown
+      >);
+      const trKeys = flattenKeys({ [branch]: commonTr[branch as keyof typeof commonTr] } as Record<
+        string,
+        unknown
+      >);
+      expect(trKeys).toEqual(enKeys);
+    }
+  );
+});

--- a/packages/i18n/src/namespaces/common/en.json
+++ b/packages/i18n/src/namespaces/common/en.json
@@ -131,11 +131,35 @@
     "openChat": "Open chat",
     "showQr": "Show QR",
     "renewMembership": "Renew membership",
-    "bookClassHint": "Booking lands in the next surface.",
+    "bookClassHint": "See upcoming classes from your gym schedule.",
     "openChatHint": "Continue the latest conversation.",
     "showQrHint": "Open the member pass in membership.",
     "renewMembershipHint": "Renew before your access expires.",
+    "discoverGyms": "Discover gyms",
+    "discoverGymsHint": "Browse nearby gyms and trial-ready listings.",
+    "trackProgress": "Progress",
+    "trackProgressHint": "Workouts and measurements will sync here.",
     "comingSoon": "Coming soon"
+  },
+  "memberBooking": {
+    "title": "Classes & schedule",
+    "subtitle": "Upcoming sessions you can book or join from your gym.",
+    "loadingTitle": "Loading schedule...",
+    "loadingBody": "Fetching the latest class sessions from your gym.",
+    "errorTitle": "Schedule could not be loaded",
+    "errorBody": "Pull to refresh or try again when you are back online.",
+    "emptyTitle": "No upcoming sessions",
+    "emptyBody": "When your gym publishes classes, they will appear here for booking."
+  },
+  "memberDiscovery": {
+    "title": "Discover gyms",
+    "subtitle": "Search and compare gyms that match your goals.",
+    "body": "Map-based discovery and trial booking will connect to the marketplace APIs as Epic #35 lands."
+  },
+  "memberProgress": {
+    "title": "Your progress",
+    "subtitle": "Workouts, check-ins, and measurements in one timeline.",
+    "body": "Progress sync and charts will appear after workout logging APIs are wired (Epic #30)."
   },
   "paymentsDashboard": {
     "body": "When payment or renewal reminders are ready, they will surface here."

--- a/packages/i18n/src/namespaces/common/tr.json
+++ b/packages/i18n/src/namespaces/common/tr.json
@@ -131,11 +131,35 @@
     "openChat": "Sohbeti aç",
     "showQr": "QR göster",
     "renewMembership": "Üyeliği yenile",
-    "bookClassHint": "Rezervasyon akışı bir sonraki alanda gelecek.",
+    "bookClassHint": "Salon takvimindeki yaklasan derslere goz atin.",
     "openChatHint": "Son görüşmeyi sürdürün.",
     "showQrHint": "Üye kartını üyelik ekranında açın.",
     "renewMembershipHint": "Erişim süresi dolmadan yenileyin.",
+    "discoverGyms": "Salon kesfet",
+    "discoverGymsHint": "Yakin salonlari ve deneme icin uygun listeleri inceleyin.",
+    "trackProgress": "Ilerleme",
+    "trackProgressHint": "Antrenman ve olcumler burada senkronize olacak.",
     "comingSoon": "Yakında"
+  },
+  "memberBooking": {
+    "title": "Dersler ve takvim",
+    "subtitle": "Rezerve edebileceginiz veya katilabileceginiz yaklasan seanslar.",
+    "loadingTitle": "Takvim yukleniyor...",
+    "loadingBody": "Salonunuzdan son ders seanslari aliniyor.",
+    "errorTitle": "Takvim yuklenemedi",
+    "errorBody": "Yenilemek icin asagi cekin veya baglanti kuruldugunda tekrar deneyin.",
+    "emptyTitle": "Yaklasan seans yok",
+    "emptyBody": "Salonunuz ders yayinladiginda burada listelenecek."
+  },
+  "memberDiscovery": {
+    "title": "Salon kesfi",
+    "subtitle": "Hedeflerinize uygun salonlari arayin ve karsilastirin.",
+    "body": "Harita tabanli kesif ve deneme rezervasyonu Epic #35 ile marketplace API'lerine baglanacak."
+  },
+  "memberProgress": {
+    "title": "Ilerlemeniz",
+    "subtitle": "Antrenmanlar, girisler ve olcumler tek zaman cizelgesinde.",
+    "body": "Ilerleme senkronu ve grafikler antrenman API'leri baglandiktan sonra gorunecek (Epic #30)."
   },
   "paymentsDashboard": {
     "body": "Ödeme veya yenileme hatırlatıcıları hazır olduğunda burada görünecek."


### PR DESCRIPTION
## Summary
- **#140**  — real `api.bookings.listSessions` + pull-to-refresh, locale-aware dates
- **#141**  — localized foundation (marketplace wiring deferred per Epic #35)
- **#142**  — localized foundation (workout APIs deferred)
- i18n: `memberBooking`, `memberDiscovery`, `memberProgress`, quick action keys (en/tr)
- Dashboard: 6 quick actions including book / discover / progress

Closes #140
Closes #141
Closes #142

Made with [Cursor](https://cursor.com)