### PR TITLE
feat(web-gym-admin): Epic #32 shell, metrics, operational stubs

### DIFF
--- a/apps/web-gym-admin/app/[locale]/campaigns/page.tsx
+++ b/apps/web-gym-admin/app/[locale]/campaigns/page.tsx
@@ -1,0 +1,25 @@
+import { setRequestLocale, getTranslations } from 'next-intl/server';
+
+type Props = {
+  params: Promise<{ locale: string }>;
+};
+
+export default async function CampaignsPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  const t = await getTranslations('common');
+
+  return (
+    <main style={{ padding: '1.5rem', fontFamily: 'sans-serif' }}>
+      <div style={{ maxWidth: 960, margin: '0 auto' }}>
+        <h1 style={{ fontSize: '1.75rem', margin: 0 }}>{t('gymAdminWeb.campaignsPage.title')}</h1>
+        <p style={{ color: '#475569', marginTop: '0.5rem' }}>
+          {t('gymAdminWeb.campaignsPage.subtitle')}
+        </p>
+        <p style={{ color: '#64748b', marginTop: '1.25rem' }}>
+          {t('gymAdminWeb.campaignsPage.placeholder')}
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/apps/web-gym-admin/app/[locale]/layout.tsx
+++ b/apps/web-gym-admin/app/[locale]/layout.tsx
@@ -2,11 +2,9 @@ import { NextIntlClientProvider } from 'next-intl';
 import { notFound } from 'next/navigation';
 import { getMessages } from 'next-intl/server';
 import { setRequestLocale } from 'next-intl/server';
-import { getTranslations } from 'next-intl/server';
 import { routing } from '@/src/i18n/routing';
-import { AppLanguageSwitcher } from '@/src/components/AppLanguageSwitcher';
 import { ChatApiProvider } from '@/src/contexts/ChatApiContext';
-import { ChatNav } from '@/src/components/ChatNav';
+import { GymAdminShell } from '@/src/components/GymAdminShell';
 
 type Props = {
   children: React.ReactNode;
@@ -26,59 +24,11 @@ export default async function LocaleLayout({ children, params }: Props) {
   setRequestLocale(locale);
 
   const messages = await getMessages();
-  const t = await getTranslations('common');
 
   return (
     <NextIntlClientProvider messages={messages}>
       <ChatApiProvider>
-        <header
-          style={{
-            padding: '1rem 1.25rem',
-            borderBottom: '1px solid #dbe4ee',
-            background:
-              'linear-gradient(180deg, rgba(248,250,252,0.98) 0%, rgba(241,245,249,0.94) 100%)',
-            position: 'sticky',
-            top: 0,
-            zIndex: 10,
-            backdropFilter: 'blur(12px)',
-          }}
-        >
-          <div
-            style={{
-              maxWidth: 1280,
-              margin: '0 auto',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-              gap: '1rem',
-              flexWrap: 'wrap',
-            }}
-          >
-            <div style={{ display: 'grid', gap: '0.2rem' }}>
-              <span
-                style={{
-                  fontSize: '0.72rem',
-                  letterSpacing: '0.12em',
-                  textTransform: 'uppercase',
-                  color: '#64748b',
-                  fontWeight: 700,
-                }}
-              >
-                {t('adminShell.eyebrow')}
-              </span>
-              <div style={{ fontSize: '1.15rem', fontWeight: 700, color: '#0f172a' }}>
-                {t('adminShell.title')}
-              </div>
-            </div>
-            <div
-              style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', flexWrap: 'wrap' }}
-            >
-              <ChatNav />
-              <AppLanguageSwitcher />
-            </div>
-          </div>
-        </header>
-        <>{children}</>
+        <GymAdminShell>{children}</GymAdminShell>
       </ChatApiProvider>
     </NextIntlClientProvider>
   );

--- a/apps/web-gym-admin/app/[locale]/listing/page.tsx
+++ b/apps/web-gym-admin/app/[locale]/listing/page.tsx
@@ -1,0 +1,25 @@
+import { setRequestLocale, getTranslations } from 'next-intl/server';
+
+type Props = {
+  params: Promise<{ locale: string }>;
+};
+
+export default async function ListingPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  const t = await getTranslations('common');
+
+  return (
+    <main style={{ padding: '1.5rem', fontFamily: 'sans-serif' }}>
+      <div style={{ maxWidth: 960, margin: '0 auto' }}>
+        <h1 style={{ fontSize: '1.75rem', margin: 0 }}>{t('gymAdminWeb.listingPage.title')}</h1>
+        <p style={{ color: '#475569', marginTop: '0.5rem' }}>
+          {t('gymAdminWeb.listingPage.subtitle')}
+        </p>
+        <p style={{ color: '#64748b', marginTop: '1.25rem' }}>
+          {t('gymAdminWeb.listingPage.placeholder')}
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/apps/web-gym-admin/app/[locale]/members/page.tsx
+++ b/apps/web-gym-admin/app/[locale]/members/page.tsx
@@ -1,0 +1,25 @@
+import { setRequestLocale, getTranslations } from 'next-intl/server';
+
+type Props = {
+  params: Promise<{ locale: string }>;
+};
+
+export default async function MembersPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  const t = await getTranslations('common');
+
+  return (
+    <main style={{ padding: '1.5rem', fontFamily: 'sans-serif' }}>
+      <div style={{ maxWidth: 960, margin: '0 auto' }}>
+        <h1 style={{ fontSize: '1.75rem', margin: 0 }}>{t('gymAdminWeb.membersPage.title')}</h1>
+        <p style={{ color: '#475569', marginTop: '0.5rem' }}>
+          {t('gymAdminWeb.membersPage.subtitle')}
+        </p>
+        <p style={{ color: '#64748b', marginTop: '1.25rem' }}>
+          {t('gymAdminWeb.membersPage.placeholder')}
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/apps/web-gym-admin/app/[locale]/page.tsx
+++ b/apps/web-gym-admin/app/[locale]/page.tsx
@@ -1,5 +1,6 @@
 import { setRequestLocale, getTranslations } from 'next-intl/server';
 import { Link } from '@/src/i18n/navigation';
+import { DashboardMetrics } from '@/src/components/DashboardMetrics';
 
 type Props = {
   params: Promise<{ locale: string }>;
@@ -42,6 +43,8 @@ export default async function HomePage({ params }: Props) {
           <h1 style={{ margin: '0.65rem 0 0.5rem', fontSize: '2rem' }}>{t('adminShell.title')}</h1>
           <p style={{ margin: 0, maxWidth: 720, color: '#cbd5e1' }}>{t('adminShell.subtitle')}</p>
         </section>
+
+        <DashboardMetrics />
 
         <section
           style={{
@@ -115,9 +118,11 @@ export default async function HomePage({ params }: Props) {
                 background: '#f0fdfa',
               }}
             >
-              <div style={{ fontSize: '1.15rem', fontWeight: 700 }}>Local dev login</div>
+              <div style={{ fontSize: '1.15rem', fontWeight: 700 }}>
+                {t('gymAdminWeb.devLoginCardTitle')}
+              </div>
               <p style={{ margin: '0.4rem 0 0', color: '#475569' }}>
-                Mint a local bearer token for the gym-admin BFF during development.
+                {t('gymAdminWeb.devLoginCardBody')}
               </p>
             </Link>
           ) : null}

--- a/apps/web-gym-admin/app/[locale]/reports/page.tsx
+++ b/apps/web-gym-admin/app/[locale]/reports/page.tsx
@@ -1,0 +1,25 @@
+import { setRequestLocale, getTranslations } from 'next-intl/server';
+
+type Props = {
+  params: Promise<{ locale: string }>;
+};
+
+export default async function ReportsPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  const t = await getTranslations('common');
+
+  return (
+    <main style={{ padding: '1.5rem', fontFamily: 'sans-serif' }}>
+      <div style={{ maxWidth: 960, margin: '0 auto' }}>
+        <h1 style={{ fontSize: '1.75rem', margin: 0 }}>{t('gymAdminWeb.reportsPage.title')}</h1>
+        <p style={{ color: '#475569', marginTop: '0.5rem' }}>
+          {t('gymAdminWeb.reportsPage.subtitle')}
+        </p>
+        <p style={{ color: '#64748b', marginTop: '1.25rem' }}>
+          {t('gymAdminWeb.reportsPage.placeholder')}
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/apps/web-gym-admin/package.json
+++ b/apps/web-gym-admin/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@myclup/analytics": "workspace:*",
     "@myclup/api-client": "workspace:*",
     "@myclup/contracts": "workspace:*",
     "@myclup/types": "workspace:*",

--- a/apps/web-gym-admin/src/components/DashboardMetrics.tsx
+++ b/apps/web-gym-admin/src/components/DashboardMetrics.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useLocale, useTranslations } from 'next-intl';
+import {
+  ANALYTICS_SCHEMA_VERSION,
+  McGa4Event,
+  createNoopAnalyticsEmitter,
+} from '@myclup/analytics';
+import { getApi } from '@/src/lib/api';
+
+export function DashboardMetrics() {
+  const t = useTranslations('common');
+  const locale = useLocale();
+  const [sessionCount, setSessionCount] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const analytics = createNoopAnalyticsEmitter();
+    analytics.track(McGa4Event.screen_view, {
+      schema_version: ANALYTICS_SCHEMA_VERSION,
+      surface: 'web_gym_admin',
+      locale,
+      screen_name: 'gym_admin_dashboard',
+      screen_class: 'WebGymAdminHome',
+    });
+
+    void getApi()
+      .bookings.listSessions({ limit: 200 })
+      .then((res) => {
+        setSessionCount(res.items?.length ?? 0);
+        setError(null);
+      })
+      .catch((e: unknown) => {
+        setSessionCount(null);
+        setError(e instanceof Error ? e.message : t('gymAdminWeb.metricsError'));
+      });
+  }, [locale, t]);
+
+  return (
+    <section
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+        gap: '1rem',
+        marginTop: '1.25rem',
+      }}
+    >
+      <div
+        style={{
+          padding: '1.1rem',
+          borderRadius: 16,
+          border: '1px solid #e2e8f0',
+          background: '#f8fafc',
+        }}
+      >
+        <div style={{ fontSize: '0.75rem', textTransform: 'uppercase', color: '#64748b' }}>
+          {t('gymAdminWeb.metrics.sessionsLabel')}
+        </div>
+        <div style={{ fontSize: '1.75rem', fontWeight: 800, marginTop: 6, color: '#0f172a' }}>
+          {sessionCount === null ? '—' : sessionCount}
+        </div>
+        {error ? (
+          <div style={{ fontSize: '0.8rem', color: '#b91c1c', marginTop: 8 }}>{error}</div>
+        ) : (
+          <div style={{ fontSize: '0.85rem', color: '#64748b', marginTop: 8 }}>
+            {t('gymAdminWeb.metrics.sessionsHint')}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web-gym-admin/src/components/GymAdminShell.tsx
+++ b/apps/web-gym-admin/src/components/GymAdminShell.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Link, usePathname, useRouter } from '@/src/i18n/navigation';
+import { AppLanguageSwitcher } from '@/src/components/AppLanguageSwitcher';
+import { getApi } from '@/src/lib/api';
+import {
+  getGymAdminSidebarVisibility,
+  rolesFromWhoami,
+  type GymNavKey,
+} from '@/src/features/gym-admin/navVisibility';
+import type { WhoamiResponse } from '@myclup/contracts/auth';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+const NAV_ORDER: { key: GymNavKey; href: string }[] = [
+  { key: 'dashboard', href: '/' },
+  { key: 'members', href: '/members' },
+  { key: 'schedule', href: '/schedule' },
+  { key: 'chat', href: '/chat' },
+  { key: 'membershipPlans', href: '/membership-plans' },
+  { key: 'billing', href: '/billing' },
+  { key: 'campaigns', href: '/campaigns' },
+  { key: 'reports', href: '/reports' },
+  { key: 'listing', href: '/listing' },
+];
+
+export function GymAdminShell({ children }: Props) {
+  const t = useTranslations('common');
+  const router = useRouter();
+  const pathname = usePathname();
+  const [whoami, setWhoami] = useState<WhoamiResponse | null>(null);
+  const [authReady, setAuthReady] = useState(false);
+
+  const skipAuth = pathname?.includes('/dev-login') ?? false;
+
+  useEffect(() => {
+    if (skipAuth) {
+      setAuthReady(true);
+      return;
+    }
+
+    let cancelled = false;
+    void getApi()
+      .auth.whoami()
+      .then((res) => {
+        if (!cancelled) {
+          setWhoami(res as WhoamiResponse);
+          setAuthReady(true);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          router.replace(`/dev-login`);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [skipAuth, router]);
+
+  const visibility = useMemo(() => {
+    const roles = whoami ? rolesFromWhoami(whoami.roles) : [];
+    return getGymAdminSidebarVisibility(roles);
+  }, [whoami]);
+
+  const linkLabel = (key: GymNavKey) => t(`gymAdminWeb.sidebar.${key}`);
+
+  const linkStyle = (href: string) => {
+    const active = href === '/' ? pathname === '/' : pathname?.startsWith(href);
+    return {
+      display: 'block',
+      padding: '0.55rem 0.85rem',
+      textDecoration: 'none',
+      color: active ? '#0f766e' : '#334155',
+      fontWeight: active ? 700 : 500,
+      borderRadius: 10,
+      background: active ? 'rgba(15,118,110,0.1)' : 'transparent',
+      fontSize: '0.95rem',
+    } as const;
+  };
+
+  if (skipAuth) {
+    return <>{children}</>;
+  }
+
+  if (!authReady) {
+    return (
+      <div
+        style={{
+          minHeight: '50vh',
+          display: 'grid',
+          placeItems: 'center',
+          fontFamily: 'sans-serif',
+          color: '#475569',
+        }}
+      >
+        {t('gymAdminWeb.authChecking')}
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', minHeight: '100vh', fontFamily: 'sans-serif' }}>
+      <aside
+        style={{
+          width: 260,
+          flexShrink: 0,
+          borderRight: '1px solid #e2e8f0',
+          background: '#f8fafc',
+          display: 'flex',
+          flexDirection: 'column',
+          padding: '1rem 0.75rem',
+          gap: '1rem',
+        }}
+      >
+        <div style={{ padding: '0 0.5rem' }}>
+          <div
+            style={{
+              fontSize: '0.7rem',
+              letterSpacing: '0.1em',
+              textTransform: 'uppercase',
+              color: '#64748b',
+              fontWeight: 700,
+            }}
+          >
+            {t('adminShell.eyebrow')}
+          </div>
+          <div style={{ fontSize: '1.1rem', fontWeight: 800, color: '#0f172a', marginTop: 6 }}>
+            {t('gymAdminWeb.productName')}
+          </div>
+          {whoami ? (
+            <div style={{ fontSize: '0.8rem', color: '#64748b', marginTop: 8 }}>
+              {whoami.profile.displayName}
+            </div>
+          ) : null}
+        </div>
+
+        <nav style={{ display: 'grid', gap: 4 }}>
+          {NAV_ORDER.filter((item) => visibility[item.key]).map((item) => (
+            <Link key={item.key} href={item.href} style={linkStyle(item.href)}>
+              {linkLabel(item.key)}
+            </Link>
+          ))}
+        </nav>
+
+        <div style={{ marginTop: 'auto', display: 'grid', gap: 12, padding: '0 0.25rem' }}>
+          {process.env.NODE_ENV === 'development' ? (
+            <Link href="/dev-login" style={{ ...linkStyle('/dev-login'), fontSize: '0.85rem' }}>
+              {t('gymAdminWeb.devLoginNav')}
+            </Link>
+          ) : null}
+          <AppLanguageSwitcher />
+        </div>
+      </aside>
+      <div style={{ flex: 1, minWidth: 0, background: '#ffffff' }}>{children}</div>
+    </div>
+  );
+}

--- a/apps/web-gym-admin/src/features/gym-admin/navVisibility.test.ts
+++ b/apps/web-gym-admin/src/features/gym-admin/navVisibility.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { getGymAdminSidebarVisibility } from './navVisibility';
+
+describe('getGymAdminSidebarVisibility', () => {
+  it('enables all items for platform admin', () => {
+    const v = getGymAdminSidebarVisibility(['platform_admin']);
+    expect(Object.values(v).every(Boolean)).toBe(true);
+  });
+
+  it('hides campaigns for instructor-only', () => {
+    const v = getGymAdminSidebarVisibility(['gym_instructor']);
+    expect(v.schedule).toBe(true);
+    expect(v.campaigns).toBe(false);
+    expect(v.reports).toBe(false);
+  });
+
+  it('shows campaigns for sales', () => {
+    const v = getGymAdminSidebarVisibility(['gym_sales']);
+    expect(v.campaigns).toBe(true);
+  });
+
+  it('minimal nav when roles unknown', () => {
+    const v = getGymAdminSidebarVisibility([]);
+    expect(v.dashboard).toBe(true);
+    expect(v.members).toBe(false);
+    expect(v.schedule).toBe(true);
+  });
+});

--- a/apps/web-gym-admin/src/features/gym-admin/navVisibility.ts
+++ b/apps/web-gym-admin/src/features/gym-admin/navVisibility.ts
@@ -1,0 +1,97 @@
+import type { WhoamiResponse } from '@myclup/contracts/auth';
+
+export type StaffRole = WhoamiResponse['roles'][number]['role'];
+
+export type GymNavKey =
+  | 'dashboard'
+  | 'members'
+  | 'membershipPlans'
+  | 'billing'
+  | 'schedule'
+  | 'chat'
+  | 'campaigns'
+  | 'reports'
+  | 'listing';
+
+export function rolesFromWhoami(assignments: WhoamiResponse['roles']): StaffRole[] {
+  return assignments.map((a) => a.role);
+}
+
+const PLATFORM: StaffRole[] = ['platform_admin', 'platform_support', 'platform_finance'];
+
+function hasAnyRole(roles: Set<StaffRole>, allowed: StaffRole[]): boolean {
+  return allowed.some((r) => roles.has(r));
+}
+
+/**
+ * Role-aware primary navigation for gym admin web (sidebar).
+ */
+export function getGymAdminSidebarVisibility(roles: StaffRole[]): Record<GymNavKey, boolean> {
+  if (roles.length === 0) {
+    return {
+      dashboard: true,
+      members: false,
+      membershipPlans: false,
+      billing: false,
+      schedule: true,
+      chat: true,
+      campaigns: false,
+      reports: false,
+      listing: false,
+    };
+  }
+
+  const set = new Set(roles);
+  if (hasAnyRole(set, PLATFORM)) {
+    const all: Record<GymNavKey, boolean> = {
+      dashboard: true,
+      members: true,
+      membershipPlans: true,
+      billing: true,
+      schedule: true,
+      chat: true,
+      campaigns: true,
+      reports: true,
+      listing: true,
+    };
+    return all;
+  }
+
+  const ops: StaffRole[] = [
+    'gym_owner',
+    'gym_manager',
+    'branch_manager',
+    'gym_staff',
+    'gym_receptionist',
+    'gym_sales',
+    'gym_instructor',
+    'branch_instructor',
+    'branch_staff',
+  ];
+
+  const financeOps: StaffRole[] = ['gym_owner', 'gym_manager', 'branch_manager', 'gym_staff'];
+
+  const campaignOps: StaffRole[] = [
+    'gym_owner',
+    'gym_manager',
+    'gym_sales',
+    'gym_receptionist',
+    'branch_manager',
+  ];
+
+  const reportOps: StaffRole[] = ['gym_owner', 'gym_manager', 'branch_manager'];
+
+  const listingOps: StaffRole[] = ['gym_owner', 'gym_manager', 'branch_manager'];
+
+  return {
+    dashboard: hasAnyRole(set, ops),
+    members: hasAnyRole(set, ops),
+    membershipPlans: hasAnyRole(set, financeOps),
+    billing: hasAnyRole(set, financeOps),
+    schedule: hasAnyRole(set, ops),
+    chat: hasAnyRole(set, ops),
+    campaigns: hasAnyRole(set, campaignOps),
+    reports: hasAnyRole(set, reportOps),
+    listing: hasAnyRole(set, listingOps),
+  };
+}

--- a/apps/web-gym-admin/src/lib/api.ts
+++ b/apps/web-gym-admin/src/lib/api.ts
@@ -18,8 +18,13 @@ async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
   return res.json() as Promise<T>;
 }
 
-const withCredentials: typeof fetch = (input, init) =>
-  fetch(input, { credentials: 'include', ...init });
+/** Same-origin BFF fetch with cookies + dev bearer token (localStorage). */
+const bffFetch: typeof fetch = (input, init) =>
+  fetch(input, {
+    credentials: 'include',
+    ...init,
+    headers: withDevAccessToken(init?.headers),
+  });
 
 type WhoamiResponse = {
   user: { id: string };
@@ -31,7 +36,7 @@ type WhoamiResponse = {
 const sharedApi = () =>
   createApi({
     baseUrl: getBaseUrl(),
-    fetch: withCredentials,
+    fetch: bffFetch,
   });
 
 const api = {

--- a/docs/03-user-admin-panel-plan.md
+++ b/docs/03-user-admin-panel-plan.md
@@ -203,3 +203,7 @@ Permissions should support:
 - Franchise management
 - Advanced accounting exports
 - White-label branch pages
+
+## 10. QA, localization, and analytics
+
+Implementation notes, test expectations, and `gymAdminWeb` i18n parity rules for `apps/web-gym-admin` are in **`docs/20-web-gym-admin-qa-localization.md`**. Product analytics taxonomy is in **`docs/18-analytics-observability-spec.md`**.

--- a/docs/20-web-gym-admin-qa-localization.md
+++ b/docs/20-web-gym-admin-qa-localization.md
@@ -1,0 +1,41 @@
+# Web Gym Admin (`apps/web-gym-admin`) — QA and localization acceptance
+
+This document satisfies **#177** (Epic #32). It complements `docs/07-technical-plan.md` §10 and workspace testing rules.
+
+## 1. Automated tests
+
+| Layer | Scope | Tool |
+|-------|--------|------|
+| Unit | Pure helpers (e.g. `navVisibility`), schema parsers | Vitest |
+| API route | BFF handlers with mocked server modules | Vitest + `NextRequest` |
+| Component | Client shells with RTL where logic warrants | Vitest + Testing Library |
+
+**Minimum:** new role or navigation rules require updates to `navVisibility` tests; new BFF contracts require route tests.
+
+## 2. Playwright E2E expectations
+
+Critical journeys (to be automated incrementally):
+
+- Locale switch preserves path (`next-intl` routing).
+- Dev login → dashboard loads metrics card without unhandled errors.
+- Schedule and chat surfaces load for an authenticated staff user.
+
+## 3. Localization
+
+- No hardcoded user-visible strings in `app/` or feature components; use `next-intl` and `common` (or domain) messages from `@myclup/i18n`.
+- **English and Turkish** parity for new keys under `common.gymAdminWeb.*` (see `packages/i18n/src/__tests__/common-gym-admin-web-keys.test.ts`).
+
+## 4. Tenant isolation and permissions
+
+- All data mutations go through `/api/v1/*` BFF routes that validate **Supabase session**, **tenant scope**, and **role** server-side.
+- UI role-aware nav (`GymAdminShell`) is **supplementary**; never rely on it for authorization.
+
+## 5. Analytics
+
+- Product analytics use `@myclup/analytics` taxonomy (`docs/18-analytics-observability-spec.md`).
+- Dashboard and future admin actions should emit events via a shared emitter; noop is acceptable until GA4 wiring is configured per environment.
+
+## 6. Accessibility baseline
+
+- Focus order: sidebar → main content; visible focus styles on links.
+- Primary headings (`h1`) per route for screen reader structure.

--- a/packages/i18n/src/__tests__/common-gym-admin-web-keys.test.ts
+++ b/packages/i18n/src/__tests__/common-gym-admin-web-keys.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import commonEn from '../namespaces/common/en.json';
+import commonTr from '../namespaces/common/tr.json';
+
+function keysDeep(obj: Record<string, unknown>, prefix = ''): string[] {
+  const out: string[] = [];
+  for (const [k, v] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${k}` : k;
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      out.push(...keysDeep(v as Record<string, unknown>, path));
+    } else {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+describe('common gymAdminWeb keys (en/tr parity)', () => {
+  it('matches nested keys between locales', () => {
+    const enBranch = commonEn.gymAdminWeb as Record<string, unknown> | undefined;
+    const trBranch = commonTr.gymAdminWeb as Record<string, unknown> | undefined;
+    expect(enBranch).toBeDefined();
+    expect(trBranch).toBeDefined();
+    expect(keysDeep(trBranch!).sort()).toEqual(keysDeep(enBranch!).sort());
+  });
+});

--- a/packages/i18n/src/namespaces/common/en.json
+++ b/packages/i18n/src/namespaces/common/en.json
@@ -109,6 +109,49 @@
     "empty": "No leads captured yet.",
     "sourceUnknown": "Unknown source"
   },
+  "gymAdminWeb": {
+    "productName": "Gym admin",
+    "authChecking": "Checking your session…",
+    "devLoginNav": "Dev login",
+    "devLoginCardTitle": "Local dev login",
+    "devLoginCardBody": "Mint a local bearer token for the gym-admin BFF during development.",
+    "metricsError": "Could not load metrics",
+    "metrics": {
+      "sessionsLabel": "Sessions in view",
+      "sessionsHint": "Loaded from the shared booking API for your tenant."
+    },
+    "sidebar": {
+      "dashboard": "Dashboard",
+      "members": "Members",
+      "membershipPlans": "Membership plans",
+      "billing": "Billing",
+      "schedule": "Schedule",
+      "chat": "Chat",
+      "campaigns": "Campaigns",
+      "reports": "Reports",
+      "listing": "Public listing"
+    },
+    "membersPage": {
+      "title": "Members",
+      "subtitle": "Directory, enrollment, and profile updates stay tenant-scoped via the BFF.",
+      "placeholder": "Member list and search will use the directory API when it lands."
+    },
+    "campaignsPage": {
+      "title": "Campaigns",
+      "subtitle": "Create and target member segments; delivery stays locale-aware.",
+      "placeholder": "Campaign composer and scheduling will connect to the messaging subsystem."
+    },
+    "reportsPage": {
+      "title": "Reports",
+      "subtitle": "Operational summaries for attendance, bookings, memberships, and revenue.",
+      "placeholder": "Report builders will aggregate audited, tenant-scoped data only."
+    },
+    "listingPage": {
+      "title": "Discovery listing",
+      "subtitle": "Manage public gym profile, amenities, photos, and visibility for marketplace discovery.",
+      "placeholder": "Listing forms will sync to discovery services under Epic #35."
+    }
+  },
   "scheduleWorkspace": {
     "heroTitle": "Calendar, capacity, and attendance",
     "heroSubtitle": "Track the next sessions, keep participant rosters current, and update attendance without leaving the shared booking flow.",

--- a/packages/i18n/src/namespaces/common/tr.json
+++ b/packages/i18n/src/namespaces/common/tr.json
@@ -109,6 +109,49 @@
     "empty": "Henüz kayıt yok.",
     "sourceUnknown": "Kaynak bilinmiyor"
   },
+  "gymAdminWeb": {
+    "productName": "Salon yönetimi",
+    "authChecking": "Oturumunuz doğrulanıyor…",
+    "devLoginNav": "Geliştirici girişi",
+    "devLoginCardTitle": "Yerel geliştirici girişi",
+    "devLoginCardBody": "Geliştirme sırasında gym-admin BFF için yerel bearer üretin.",
+    "metricsError": "Metrikler yüklenemedi",
+    "metrics": {
+      "sessionsLabel": "Görünümdeki seanslar",
+      "sessionsHint": "Kiracınız için paylaşılan rezervasyon API’sinden yüklenir."
+    },
+    "sidebar": {
+      "dashboard": "Panel",
+      "members": "Üyeler",
+      "membershipPlans": "Üyelik planları",
+      "billing": "Faturalama",
+      "schedule": "Takvim",
+      "chat": "Sohbet",
+      "campaigns": "Kampanyalar",
+      "reports": "Raporlar",
+      "listing": "Herkese açık liste"
+    },
+    "membersPage": {
+      "title": "Üyeler",
+      "subtitle": "Dizin, kayıt ve profil güncellemeleri BFF üzerinden kiracı kapsamında kalır.",
+      "placeholder": "Üye listesi ve arama dizin API’si hazır olduğunda kullanılacak."
+    },
+    "campaignsPage": {
+      "title": "Kampanyalar",
+      "subtitle": "Üye segmentleri oluşturun ve hedefleyin; teslimat dil bilincine sahiptir.",
+      "placeholder": "Kampanya oluşturucu mesajlaşma alt sistemine bağlanacak."
+    },
+    "reportsPage": {
+      "title": "Raporlar",
+      "subtitle": "Yoklama, rezervasyon, üyelik ve gelir için operasyonel özetler.",
+      "placeholder": "Rapor oluşturucular yalnızca denetlenebilir kiracı verisini toplayacak."
+    },
+    "listingPage": {
+      "title": "Keşif listesi",
+      "subtitle": "Herkese açık salon profili, olanaklar, fotoğraflar ve pazar görünürlüğünü yönetin.",
+      "placeholder": "Liste formları Epic #35 altında keşif servisleriyle senkronlanacak."
+    }
+  },
   "scheduleWorkspace": {
     "heroTitle": "Takvim, kapasite ve yoklama",
     "heroSubtitle": "Yaklaşan seansları izleyin, katılımcı listelerini güncel tutun ve yoklama durumunu ortak rezervasyon akışından çıkmadan yönetin.",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,9 @@ importers:
 
   apps/web-gym-admin:
     dependencies:
+      '@myclup/analytics':
+        specifier: workspace:*
+        version: link:../../packages/analytics
       '@myclup/api-client':
         specifier: workspace:*
         version: link:../../packages/api-client


### PR DESCRIPTION
## Summary
- **#173**: Role-aware **sidebar**, **GymAdminShell** + client **whoami** gate (redirect to dev-login), dev-login path unwrapped
- **#174**: **Members** page foundation; existing **membership**, **billing**, **schedule** linked from shell; **BFF fetch** sends dev bearer token
- **#175**: **Campaigns** + **reports** stubs; dashboard **analytics** via `@myclup/analytics` (`mc_screen_view`, noop emitter)
- **#176**: **Listing** stub for discovery integration
- **#177**: `docs/20-web-gym-admin-qa-localization.md`; `common.gymAdminWeb` **en/tr** + parity test

## Validation
- `pnpm --filter @myclup/web-gym-admin run typecheck lint test`
- `pnpm --filter @myclup/i18n run test`
- `pnpm test`

Closes #173
Closes #174
Closes #175
Closes #176
Closes #177

Made with [Cursor](https://cursor.com)