### PR TITLE
feat(web-platform-admin): Epic #33 platform shell and stubs

### DIFF
--- a/apps/web-platform-admin/app/[locale]/audit/page.tsx
+++ b/apps/web-platform-admin/app/[locale]/audit/page.tsx
@@ -1,0 +1,11 @@
+import { PlatformStubPage } from '@/src/components/PlatformStubPage';
+
+type Props = { params: Promise<{ locale: string }> };
+
+export default async function AuditPage({ params }: Props) {
+  return await PlatformStubPage({
+    params,
+    titleKey: 'platformAdminWeb.auditPage.title',
+    subtitleKey: 'platformAdminWeb.auditPage.subtitle',
+  });
+}

--- a/apps/web-platform-admin/app/[locale]/billing/page.tsx
+++ b/apps/web-platform-admin/app/[locale]/billing/page.tsx
@@ -1,0 +1,11 @@
+import { PlatformStubPage } from '@/src/components/PlatformStubPage';
+
+type Props = { params: Promise<{ locale: string }> };
+
+export default async function PlatformBillingPage({ params }: Props) {
+  return await PlatformStubPage({
+    params,
+    titleKey: 'platformAdminWeb.billingPage.title',
+    subtitleKey: 'platformAdminWeb.billingPage.subtitle',
+  });
+}

--- a/apps/web-platform-admin/app/[locale]/cms/page.tsx
+++ b/apps/web-platform-admin/app/[locale]/cms/page.tsx
@@ -1,0 +1,11 @@
+import { PlatformStubPage } from '@/src/components/PlatformStubPage';
+
+type Props = { params: Promise<{ locale: string }> };
+
+export default async function CmsPage({ params }: Props) {
+  return await PlatformStubPage({
+    params,
+    titleKey: 'platformAdminWeb.cmsPage.title',
+    subtitleKey: 'platformAdminWeb.cmsPage.subtitle',
+  });
+}

--- a/apps/web-platform-admin/app/[locale]/gyms/page.tsx
+++ b/apps/web-platform-admin/app/[locale]/gyms/page.tsx
@@ -1,0 +1,11 @@
+import { PlatformStubPage } from '@/src/components/PlatformStubPage';
+
+type Props = { params: Promise<{ locale: string }> };
+
+export default async function GymsPage({ params }: Props) {
+  return await PlatformStubPage({
+    params,
+    titleKey: 'platformAdminWeb.gymsPage.title',
+    subtitleKey: 'platformAdminWeb.gymsPage.subtitle',
+  });
+}

--- a/apps/web-platform-admin/app/[locale]/layout.tsx
+++ b/apps/web-platform-admin/app/[locale]/layout.tsx
@@ -3,7 +3,7 @@ import { notFound } from 'next/navigation';
 import { getMessages } from 'next-intl/server';
 import { setRequestLocale } from 'next-intl/server';
 import { routing } from '@/src/i18n/routing';
-import { AppLanguageSwitcher } from '@/src/components/AppLanguageSwitcher';
+import { PlatformAdminShell } from '@/src/components/PlatformAdminShell';
 
 type Props = {
   children: React.ReactNode;
@@ -26,10 +26,7 @@ export default async function LocaleLayout({ children, params }: Props) {
 
   return (
     <NextIntlClientProvider messages={messages}>
-      <header style={{ padding: '0.5rem 1rem', borderBottom: '1px solid #eee' }}>
-        <AppLanguageSwitcher />
-      </header>
-      {children}
+      <PlatformAdminShell>{children}</PlatformAdminShell>
     </NextIntlClientProvider>
   );
 }

--- a/apps/web-platform-admin/app/[locale]/locales/page.tsx
+++ b/apps/web-platform-admin/app/[locale]/locales/page.tsx
@@ -1,0 +1,11 @@
+import { PlatformStubPage } from '@/src/components/PlatformStubPage';
+
+type Props = { params: Promise<{ locale: string }> };
+
+export default async function LocalesPage({ params }: Props) {
+  return await PlatformStubPage({
+    params,
+    titleKey: 'platformAdminWeb.localesPage.title',
+    subtitleKey: 'platformAdminWeb.localesPage.subtitle',
+  });
+}

--- a/apps/web-platform-admin/app/[locale]/moderation/page.tsx
+++ b/apps/web-platform-admin/app/[locale]/moderation/page.tsx
@@ -1,0 +1,11 @@
+import { PlatformStubPage } from '@/src/components/PlatformStubPage';
+
+type Props = { params: Promise<{ locale: string }> };
+
+export default async function ModerationPage({ params }: Props) {
+  return await PlatformStubPage({
+    params,
+    titleKey: 'platformAdminWeb.moderationPage.title',
+    subtitleKey: 'platformAdminWeb.moderationPage.subtitle',
+  });
+}

--- a/apps/web-platform-admin/app/[locale]/page.tsx
+++ b/apps/web-platform-admin/app/[locale]/page.tsx
@@ -9,10 +9,27 @@ export default async function HomePage({ params }: Props) {
   setRequestLocale(locale);
 
   const t = await getTranslations('common');
+
   return (
-    <main style={{ padding: '2rem', fontFamily: 'sans-serif' }}>
-      <h1>MyClup Platform Admin</h1>
-      <p>{t('label.loading')}</p>
+    <main style={{ padding: '1.5rem', fontFamily: 'sans-serif' }}>
+      <div style={{ maxWidth: 960, margin: '0 auto' }}>
+        <h1 style={{ fontSize: '1.85rem', margin: 0 }}>{t('platformAdminWeb.dashboardTitle')}</h1>
+        <p style={{ color: '#475569', marginTop: '0.65rem', maxWidth: 720 }}>
+          {t('platformAdminWeb.dashboardSubtitle')}
+        </p>
+        <section
+          style={{
+            marginTop: '1.5rem',
+            padding: '1.25rem',
+            borderRadius: 16,
+            border: '1px solid #e2e8f0',
+            background: '#f8fafc',
+            color: '#475569',
+          }}
+        >
+          {t('platformAdminWeb.metricsPlaceholder')}
+        </section>
+      </div>
     </main>
   );
 }

--- a/apps/web-platform-admin/app/[locale]/support/page.tsx
+++ b/apps/web-platform-admin/app/[locale]/support/page.tsx
@@ -1,0 +1,11 @@
+import { PlatformStubPage } from '@/src/components/PlatformStubPage';
+
+type Props = { params: Promise<{ locale: string }> };
+
+export default async function SupportPage({ params }: Props) {
+  return await PlatformStubPage({
+    params,
+    titleKey: 'platformAdminWeb.supportPage.title',
+    subtitleKey: 'platformAdminWeb.supportPage.subtitle',
+  });
+}

--- a/apps/web-platform-admin/app/[locale]/users/page.tsx
+++ b/apps/web-platform-admin/app/[locale]/users/page.tsx
@@ -1,0 +1,11 @@
+import { PlatformStubPage } from '@/src/components/PlatformStubPage';
+
+type Props = { params: Promise<{ locale: string }> };
+
+export default async function UsersPage({ params }: Props) {
+  return await PlatformStubPage({
+    params,
+    titleKey: 'platformAdminWeb.usersPage.title',
+    subtitleKey: 'platformAdminWeb.usersPage.subtitle',
+  });
+}

--- a/apps/web-platform-admin/src/components/PlatformAdminShell.tsx
+++ b/apps/web-platform-admin/src/components/PlatformAdminShell.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { Link, usePathname } from '@/src/i18n/navigation';
+import { AppLanguageSwitcher } from '@/src/components/AppLanguageSwitcher';
+
+const NAV: { href: string; key: string }[] = [
+  { href: '/', key: 'dashboard' },
+  { href: '/gyms', key: 'gyms' },
+  { href: '/users', key: 'users' },
+  { href: '/support', key: 'support' },
+  { href: '/moderation', key: 'moderation' },
+  { href: '/billing', key: 'billing' },
+  { href: '/cms', key: 'cms' },
+  { href: '/locales', key: 'locales' },
+  { href: '/audit', key: 'audit' },
+];
+
+export function PlatformAdminShell({ children }: { children: React.ReactNode }) {
+  const t = useTranslations('common');
+  const pathname = usePathname();
+
+  const linkStyle = (href: string) => {
+    const active = href === '/' ? pathname === '/' : pathname?.startsWith(href);
+    return {
+      display: 'block',
+      padding: '0.55rem 0.85rem',
+      textDecoration: 'none',
+      color: active ? '#1d4ed8' : '#334155',
+      fontWeight: active ? 700 : 500,
+      borderRadius: 10,
+      background: active ? 'rgba(29,78,216,0.08)' : 'transparent',
+      fontSize: '0.95rem',
+    } as const;
+  };
+
+  return (
+    <div style={{ display: 'flex', minHeight: '100vh', fontFamily: 'sans-serif' }}>
+      <aside
+        style={{
+          width: 270,
+          flexShrink: 0,
+          borderRight: '1px solid #e2e8f0',
+          background: '#f8fafc',
+          display: 'flex',
+          flexDirection: 'column',
+          padding: '1rem 0.75rem',
+          gap: '1rem',
+        }}
+      >
+        <div style={{ padding: '0 0.5rem' }}>
+          <div
+            style={{
+              fontSize: '0.7rem',
+              letterSpacing: '0.1em',
+              textTransform: 'uppercase',
+              color: '#64748b',
+              fontWeight: 700,
+            }}
+          >
+            {t('platformAdminWeb.eyebrow')}
+          </div>
+          <div style={{ fontSize: '1.1rem', fontWeight: 800, color: '#0f172a', marginTop: 6 }}>
+            {t('platformAdminWeb.productName')}
+          </div>
+        </div>
+        <nav style={{ display: 'grid', gap: 4 }}>
+          {NAV.map((item) => (
+            <Link key={item.href} href={item.href} style={linkStyle(item.href)}>
+              {t(`platformAdminWeb.sidebar.${item.key}`)}
+            </Link>
+          ))}
+        </nav>
+        <div style={{ marginTop: 'auto' }}>
+          <AppLanguageSwitcher />
+        </div>
+      </aside>
+      <div style={{ flex: 1, minWidth: 0, background: '#fff' }}>{children}</div>
+    </div>
+  );
+}

--- a/apps/web-platform-admin/src/components/PlatformStubPage.tsx
+++ b/apps/web-platform-admin/src/components/PlatformStubPage.tsx
@@ -1,0 +1,22 @@
+import { setRequestLocale, getTranslations } from 'next-intl/server';
+
+type StubProps = {
+  params: Promise<{ locale: string }>;
+  titleKey: string;
+  subtitleKey: string;
+};
+
+export async function PlatformStubPage({ params, titleKey, subtitleKey }: StubProps) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  const t = await getTranslations('common');
+
+  return (
+    <main style={{ padding: '1.5rem', fontFamily: 'sans-serif' }}>
+      <div style={{ maxWidth: 960, margin: '0 auto' }}>
+        <h1 style={{ fontSize: '1.75rem', margin: 0 }}>{t(titleKey)}</h1>
+        <p style={{ color: '#475569', marginTop: '0.5rem' }}>{t(subtitleKey)}</p>
+      </div>
+    </main>
+  );
+}

--- a/docs/04-admin-panel-plan.md
+++ b/docs/04-admin-panel-plan.md
@@ -152,3 +152,8 @@ Primary goals:
 - Revenue forecasting
 - Cohort analytics
 - Internal incident management
+
+## 8. Implementation references
+
+- Platform admin UI shell and QA gates: **`docs/21-web-platform-admin-qa.md`**
+- Audited elevated actions and impersonation: **`docs/23-platform-audit-elevated-actions.md`**

--- a/docs/21-web-platform-admin-qa.md
+++ b/docs/21-web-platform-admin-qa.md
@@ -1,0 +1,25 @@
+# Web Platform Admin (`apps/web-platform-admin`) — QA and release sensitivity
+
+This document satisfies **#184** (Epic #33). Elevated-action rules are in **`docs/23-platform-audit-elevated-actions.md`** (#183).
+
+## 1. Test expectations
+
+| Layer | Requirement |
+|-------|----------------|
+| Unit | Locale message loading, any future pure permission helpers |
+| Integration | Once BFF routes are mounted (or proxied), every `/api/v1/*` handler must have contract + auth tests |
+| E2E | Playwright for impersonation start/end, audit viewer access denial for non-platform roles |
+
+## 2. Localization
+
+- All UI strings use `next-intl` with keys under `common.platformAdminWeb.*`.
+- **English and Turkish** parity is enforced by `packages/i18n/src/__tests__/common-platform-admin-web-keys.test.ts`.
+
+## 3. Release sensitivity
+
+- Platform admin changes are **release-sensitive**: human approval must record who approved and when before production rollout.
+- Cross-tenant features require **audit logging** per `docs/18-analytics-observability-spec.md` §2 and `packages/supabase` audit writers.
+
+## 4. BFF wiring
+
+- This app ships with a **UI shell** first. Point `NEXT_PUBLIC_BFF_BASE_URL` at the shared BFF (e.g. gym admin Next origin in local dev) when calling `whoami` and domain APIs from the browser; long-term, platform-specific routes should live behind a single gateway with identical contract validation.

--- a/docs/23-platform-audit-elevated-actions.md
+++ b/docs/23-platform-audit-elevated-actions.md
@@ -1,0 +1,19 @@
+# Platform admin — audited elevated actions and impersonation (#183)
+
+## 1. Principles
+
+- **No silent cross-tenant access.** Any platform user acting on behalf of a tenant must go through an **explicit, time-bounded impersonation** or support workflow that is **audit-logged** before and after.
+- **Server-side only.** UI badges are not authorization. Every elevated action validates **Supabase identity**, **platform role**, and **scope** on the BFF.
+- **Audit events** must use `writeAuditEvent` with typed payloads (`packages/supabase/src/audit`) for: impersonation start/end, role grants, billing overrides visible to platform, and moderation actions that affect member-visible state.
+
+## 2. Required audit metadata
+
+- `actor_id`, `event_type`, `target_type`, `target_id`, `tenant_context` (gym/branch), structured `payload` with **reason** and **ticket reference** when applicable.
+
+## 3. UI obligations
+
+- **PlatformStubPage** routes in `web-platform-admin` are placeholders until APIs exist; shipping real mutations requires **integration tests** proving audit rows are written and RLS prevents gym users from reading platform-only audit slices.
+
+## 4. Conflicts
+
+On ambiguity, **`docs/07-technical-plan.md`** and **`docs/18-analytics-observability-spec.md`** take precedence over this note.

--- a/packages/i18n/src/__tests__/common-platform-admin-web-keys.test.ts
+++ b/packages/i18n/src/__tests__/common-platform-admin-web-keys.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import commonEn from '../namespaces/common/en.json';
+import commonTr from '../namespaces/common/tr.json';
+
+function keysDeep(obj: Record<string, unknown>, prefix = ''): string[] {
+  const out: string[] = [];
+  for (const [k, v] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${k}` : k;
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      out.push(...keysDeep(v as Record<string, unknown>, path));
+    } else {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+describe('common platformAdminWeb keys (en/tr parity)', () => {
+  it('matches nested keys between locales', () => {
+    const enBranch = commonEn.platformAdminWeb as Record<string, unknown> | undefined;
+    const trBranch = commonTr.platformAdminWeb as Record<string, unknown> | undefined;
+    expect(enBranch).toBeDefined();
+    expect(trBranch).toBeDefined();
+    expect(keysDeep(trBranch!).sort()).toEqual(keysDeep(enBranch!).sort());
+  });
+});

--- a/packages/i18n/src/namespaces/common/en.json
+++ b/packages/i18n/src/namespaces/common/en.json
@@ -152,6 +152,56 @@
       "placeholder": "Listing forms will sync to discovery services under Epic #35."
     }
   },
+  "platformAdminWeb": {
+    "eyebrow": "Platform control",
+    "productName": "Platform admin",
+    "dashboardTitle": "Platform dashboard",
+    "dashboardSubtitle": "Cross-tenant oversight, support tooling, and governance. Wire this app to the shared BFF via NEXT_PUBLIC_BFF_BASE_URL when API routes are mounted here.",
+    "metricsPlaceholder": "Operational KPIs will aggregate tenant-safe metrics once reporting endpoints are connected.",
+    "sidebar": {
+      "dashboard": "Dashboard",
+      "gyms": "Gyms & tenants",
+      "users": "Users & roles",
+      "support": "Support queue",
+      "moderation": "Moderation",
+      "billing": "Billing oversight",
+      "cms": "CMS",
+      "locales": "Localization",
+      "audit": "Audit log"
+    },
+    "gymsPage": {
+      "title": "Gyms and tenants",
+      "subtitle": "Provision gyms, branches, and entitlement flags with full audit trails."
+    },
+    "usersPage": {
+      "title": "Users and roles",
+      "subtitle": "Platform and support roles; all elevated grants must be audited."
+    },
+    "supportPage": {
+      "title": "Support",
+      "subtitle": "Cross-tenant support access only through approved impersonation flows."
+    },
+    "moderationPage": {
+      "title": "Moderation",
+      "subtitle": "Chat and content moderation with tenant isolation preserved."
+    },
+    "billingPage": {
+      "title": "Billing oversight",
+      "subtitle": "Platform-level billing health without exposing member PII unnecessarily."
+    },
+    "cmsPage": {
+      "title": "CMS operations",
+      "subtitle": "Manage global content models and locale variants for platform surfaces."
+    },
+    "localesPage": {
+      "title": "Localization operations",
+      "subtitle": "Coordinate default locales, fallbacks, and translation coverage."
+    },
+    "auditPage": {
+      "title": "Audit log",
+      "subtitle": "Read-only view over audit_events for elevated and cross-tenant actions."
+    }
+  },
   "scheduleWorkspace": {
     "heroTitle": "Calendar, capacity, and attendance",
     "heroSubtitle": "Track the next sessions, keep participant rosters current, and update attendance without leaving the shared booking flow.",

--- a/packages/i18n/src/namespaces/common/tr.json
+++ b/packages/i18n/src/namespaces/common/tr.json
@@ -152,6 +152,56 @@
       "placeholder": "Liste formları Epic #35 altında keşif servisleriyle senkronlanacak."
     }
   },
+  "platformAdminWeb": {
+    "eyebrow": "Platform kontrolü",
+    "productName": "Platform yönetimi",
+    "dashboardTitle": "Platform paneli",
+    "dashboardSubtitle": "Kiracılar arası gözetim, destek araçları ve yönetişim. API rotaları buraya taşındığında paylaşılan BFF için NEXT_PUBLIC_BFF_BASE_URL kullanın.",
+    "metricsPlaceholder": "Raporlama uçları bağlandığında operasyonel KPI’lar kiracı güvenli şekilde toplanacak.",
+    "sidebar": {
+      "dashboard": "Panel",
+      "gyms": "Salonlar ve kiracılar",
+      "users": "Kullanıcılar ve roller",
+      "support": "Destek kuyruğu",
+      "moderation": "Moderasyon",
+      "billing": "Faturalama gözetimi",
+      "cms": "CMS",
+      "locales": "Yerelleştirme",
+      "audit": "Denetim günlüğü"
+    },
+    "gymsPage": {
+      "title": "Salonlar ve kiracılar",
+      "subtitle": "Salonları, şubeleri ve yetki bayraklarını tam denetim iziyle sağlayın."
+    },
+    "usersPage": {
+      "title": "Kullanıcılar ve roller",
+      "subtitle": "Platform ve destek rolleri; tüm yükseltilmiş yetkiler denetlenmelidir."
+    },
+    "supportPage": {
+      "title": "Destek",
+      "subtitle": "Kiracılar arası destek yalnızca onaylı kimliğe bürünme akışlarıyla."
+    },
+    "moderationPage": {
+      "title": "Moderasyon",
+      "subtitle": "Sohbet ve içerik moderasyonu kiracı izolasyonu korunarak."
+    },
+    "billingPage": {
+      "title": "Faturalama gözetimi",
+      "subtitle": "Üye KVK’siz platform faturalama sağlığı."
+    },
+    "cmsPage": {
+      "title": "CMS işlemleri",
+      "subtitle": "Platform yüzeyleri için genel içerik modelleri ve dil varyantları."
+    },
+    "localesPage": {
+      "title": "Yerelleştirme işlemleri",
+      "subtitle": "Varsayılan diller, geri dönüşler ve çeviri kapsamını koordine edin."
+    },
+    "auditPage": {
+      "title": "Denetim günlüğü",
+      "subtitle": "Yükseltilmiş ve kiracılar arası işlemler için audit_events salt okunur görünümü."
+    }
+  },
   "scheduleWorkspace": {
     "heroTitle": "Takvim, kapasite ve yoklama",
     "heroSubtitle": "Yaklaşan seansları izleyin, katılımcı listelerini güncel tutun ve yoklama durumunu ortak rezervasyon akışından çıkmadan yönetin.",


### PR DESCRIPTION
## Summary
- **#179** Dashboard + **PlatformAdminShell** navigation
- **#180** Stubs: gyms, users, support, moderation, billing oversight
- **#181** CMS + localization ops pages
- **#183** `docs/23-platform-audit-elevated-actions.md`
- **#184** `docs/21-web-platform-admin-qa.md`
- i18n `platformAdminWeb.*` en/tr + parity test

> **#182** is website scope (Epic #34); not included here.

Closes #179
Closes #180
Closes #181
Closes #183
Closes #184

Made with [Cursor](https://cursor.com)