### PR TITLE
feat(discovery): Epic #35 discover page + marketplace spec

### DIFF
--- a/apps/web-site/src/app/[locale]/discover/page.tsx
+++ b/apps/web-site/src/app/[locale]/discover/page.tsx
@@ -1,0 +1,33 @@
+import { setRequestLocale, getTranslations } from 'next-intl/server';
+import type { Metadata } from 'next';
+import { routing } from '@/i18n/routing';
+import { buildPublicMetadata } from '@/lib/siteMetadata';
+
+type Props = { params: Promise<{ locale: string }> };
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  return buildPublicMetadata({
+    locale,
+    pathSuffix: '/discover',
+    titleKey: 'discoveryWeb.title',
+    descriptionKey: 'discoveryWeb.subtitle',
+  });
+}
+
+export default async function DiscoverPage({ params }: Props) {
+  const { locale } = await params;
+  if (!routing.locales.includes(locale as (typeof routing.locales)[number])) {
+    return null;
+  }
+  setRequestLocale(locale);
+  const t = await getTranslations({ locale, namespace: 'common' });
+
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-12 font-sans">
+      <h1 className="text-3xl font-bold text-gray-900">{t('discoveryWeb.title')}</h1>
+      <p className="mt-4 text-lg text-gray-600">{t('discoveryWeb.subtitle')}</p>
+      <p className="mt-6 text-gray-700">{t('discoveryWeb.body')}</p>
+    </div>
+  );
+}

--- a/apps/web-site/src/app/[locale]/layout.tsx
+++ b/apps/web-site/src/app/[locale]/layout.tsx
@@ -51,6 +51,9 @@ export default async function LocaleLayout({ children, params }: Props) {
             <Link href="/contact" className="hover:text-teal-700">
               {t('publicSite.nav.contact')}
             </Link>
+            <Link href="/discover" className="hover:text-teal-700">
+              {t('discoveryWeb.title')}
+            </Link>
             <Link href="/legal/privacy" className="hover:text-teal-700">
               {t('publicSite.nav.privacy')}
             </Link>

--- a/apps/web-site/src/app/sitemap.ts
+++ b/apps/web-site/src/app/sitemap.ts
@@ -5,7 +5,7 @@ function getBaseUrl(): string {
   return process.env.NEXT_PUBLIC_SITE_URL ?? 'https://myclup.com';
 }
 
-const STATIC_PATHS = ['', '/about', '/contact', '/legal/privacy', '/legal/terms'];
+const STATIC_PATHS = ['', '/about', '/contact', '/discover', '/legal/privacy', '/legal/terms'];
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const base = getBaseUrl();

--- a/docs/05-website-plan.md
+++ b/docs/05-website-plan.md
@@ -148,3 +148,4 @@ The website must be multilingual from the start, not treated as a later enhancem
 
 - Content governance and legal versioning: **`docs/24-website-content-governance.md`**
 - QA, performance, and analytics wiring: **`docs/25-website-qa-performance.md`**
+- Discovery marketplace boundaries and SEO: **`docs/26-discovery-marketplace.md`**

--- a/docs/26-discovery-marketplace.md
+++ b/docs/26-discovery-marketplace.md
@@ -1,0 +1,32 @@
+# Discovery marketplace — boundaries, experiences, and governance (#192, #194, #197, #199, #202)
+
+## 1. Domain boundaries (#192)
+
+- **Public discovery** surfaces (website + mobile) consume **read-optimized, tenant-scoped** listing data; they never bypass RLS or gym-admin authorization.
+- **Writes** (reviews, trial requests, leads) go through **BFF routes** with Zod contracts, explicit **consent locale**, and **audit** where the action is sensitive.
+- **Gym-managed content** is edited in **gym admin** (`/listing` stub in `web-gym-admin`); published snapshots feed discovery with version metadata.
+
+## 2. Website and mobile experience (#194)
+
+- **Website**: `/[locale]/discover` (see `apps/web-site`) with localized metadata via `buildPublicMetadata`.
+- **Mobile**: `apps/mobile-user` discovery tab uses `memberDiscovery.*` keys; parity with product intent is tested via `common-member-booking-keys.test.ts`.
+
+## 3. Content and moderation (#197)
+
+- Listing fields (name, description, amenities, media) support **per-locale variants**; moderation actions on user-generated content are **audited** and **tenant-scoped** unless platform policy applies.
+
+## 4. Reviews, trials, and lead routing (#199)
+
+- **Reviews**: structured contract; no anonymous cross-tenant writes; rate limits and report flows TBD in implementation issues.
+- **Trial requests**: create **lead** records with `locale` + `source=discovery`; route to gym **sales** workflows (see mobile-admin sales stub).
+- **Analytics**: use `McGa4Event` taxonomy; marketing/discovery events documented in `docs/18-analytics-observability-spec.md`.
+
+## 5. SEO and locale governance (#202)
+
+- Discovery indexable URLs are **locale-prefixed**; canonical and `hreflang` follow the same helper as other public pages.
+- Sitemap includes `/discover`; update `STATIC_PATHS` when adding listing detail routes.
+- Listing detail pages must expose **structured data** (e.g. `LocalBusiness`) when real data ships—track in a future implementation issue.
+
+## 6. Precedence
+
+`docs/05-website-plan.md`, `docs/07-technical-plan.md`, and workspace **website SEO** rules override this document when they conflict.

--- a/packages/i18n/src/__tests__/common-discovery-web-keys.test.ts
+++ b/packages/i18n/src/__tests__/common-discovery-web-keys.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import commonEn from '../namespaces/common/en.json';
+import commonTr from '../namespaces/common/tr.json';
+
+function keysDeep(obj: Record<string, unknown>, prefix = ''): string[] {
+  const out: string[] = [];
+  for (const [k, v] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${k}` : k;
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      out.push(...keysDeep(v as Record<string, unknown>, path));
+    } else {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+describe('common discoveryWeb keys (en/tr parity)', () => {
+  it('matches nested keys between locales', () => {
+    const enBranch = commonEn.discoveryWeb as Record<string, unknown> | undefined;
+    const trBranch = commonTr.discoveryWeb as Record<string, unknown> | undefined;
+    expect(enBranch).toBeDefined();
+    expect(trBranch).toBeDefined();
+    expect(keysDeep(trBranch!).sort()).toEqual(keysDeep(enBranch!).sort());
+  });
+});

--- a/packages/i18n/src/namespaces/common/en.json
+++ b/packages/i18n/src/namespaces/common/en.json
@@ -234,6 +234,11 @@
       "thanks": "Thanks — we will get back to you in your selected language where possible."
     }
   },
+  "discoveryWeb": {
+    "title": "Discover gyms",
+    "subtitle": "Search, compare amenities, and start a trial request when the marketplace API is enabled.",
+    "body": "Listings are tenant-owned and locale-aware. Reviews, trial requests, and lead routing will flow through audited BFF endpoints with explicit consent and SEO-safe metadata per locale."
+  },
   "scheduleWorkspace": {
     "heroTitle": "Calendar, capacity, and attendance",
     "heroSubtitle": "Track the next sessions, keep participant rosters current, and update attendance without leaving the shared booking flow.",
@@ -350,7 +355,7 @@
   "memberDiscovery": {
     "title": "Discover gyms",
     "subtitle": "Search and compare gyms that match your goals.",
-    "body": "Map-based discovery and trial booking will connect to the marketplace APIs as Epic #35 lands."
+    "body": "Map search, reviews, trial requests, and lead routing will use tenant-safe marketplace APIs with locale-aware listings (Epic #35)."
   },
   "memberProgress": {
     "title": "Your progress",

--- a/packages/i18n/src/namespaces/common/tr.json
+++ b/packages/i18n/src/namespaces/common/tr.json
@@ -234,6 +234,11 @@
       "thanks": "Teşekkürler — mümkünse seçtiğiniz dilde size dönüş yapacağız."
     }
   },
+  "discoveryWeb": {
+    "title": "Salon keşfi",
+    "subtitle": "Arama yapın, olanakları karşılaştırın; pazar API’si açıldığında deneme talebi başlatın.",
+    "body": "Listeler kiracıya aittir ve dil bilincine sahiptir. Yorumlar, deneme talepleri ve potansiyel müşteri yönlendirmesi denetlenen BFF uçları ve açık rıza ile akar; SEO meta verisi dile göre üretilir."
+  },
   "scheduleWorkspace": {
     "heroTitle": "Takvim, kapasite ve yoklama",
     "heroSubtitle": "Yaklaşan seansları izleyin, katılımcı listelerini güncel tutun ve yoklama durumunu ortak rezervasyon akışından çıkmadan yönetin.",
@@ -350,7 +355,7 @@
   "memberDiscovery": {
     "title": "Salon kesfi",
     "subtitle": "Hedeflerinize uygun salonlari arayin ve karsilastirin.",
-    "body": "Harita tabanli kesif ve deneme rezervasyonu Epic #35 ile marketplace API'lerine baglanacak."
+    "body": "Harita aramasi, yorumlar, deneme talepleri ve potansiyel müşteri yönlendirmesi kiracı güvenli marketplace API’leri ve dil bilincine sahip listelerle çalışacak (Epic #35)."
   },
   "memberProgress": {
     "title": "Ilerlemeniz",


### PR DESCRIPTION
## Summary
- **#192–#202**: `docs/26-discovery-marketplace.md` (boundaries, moderation, lead routing, SEO)
- **#194**: `/discover` on `web-site`, nav + sitemap
- **#202**: `buildPublicMetadata` + `discoveryWeb` strings
- **Mobile**: `memberDiscovery.body` aligned with marketplace intent
- i18n parity test for `discoveryWeb`

Closes #192
Closes #194
Closes #197
Closes #199
Closes #202

Made with [Cursor](https://cursor.com)