### PR TITLE
feat(issues-229-235): platform admin BFF and oversight pages

### DIFF
--- a/apps/web-platform-admin/app/[locale]/audit/page.tsx
+++ b/apps/web-platform-admin/app/[locale]/audit/page.tsx
@@ -1,11 +1,39 @@
-import { PlatformStubPage } from '@/src/components/PlatformStubPage';
+import { setRequestLocale, getTranslations } from 'next-intl/server';
+import { PlatformPreviewTable } from '@/src/components/PlatformPreviewTable';
+import { listRecentAuditEvents } from '@/src/server/platform/data';
+import { assertPlatformPageAuth } from '@/src/server/platform/page-auth';
 
 type Props = { params: Promise<{ locale: string }> };
 
 export default async function AuditPage({ params }: Props) {
-  return await PlatformStubPage({
-    params,
-    titleKey: 'platformAdminWeb.auditPage.title',
-    subtitleKey: 'platformAdminWeb.auditPage.subtitle',
-  });
+  const { locale } = await params;
+  await assertPlatformPageAuth(locale);
+  setRequestLocale(locale);
+  const t = await getTranslations('common');
+  const dp = (key: string) => t(`platformAdminWeb.dataPreview.${key}`);
+  const { events } = await listRecentAuditEvents();
+
+  const rows = events.map((e) => ({
+    time: e.created_at.slice(0, 19).replace('T', ' '),
+    eventType: e.event_type,
+    actor: e.actor_id ?? '—',
+    target: `${e.target_type}${e.target_id ? `:${e.target_id.slice(0, 8)}…` : ''}`,
+  }));
+
+  const columns = [
+    { key: 'time', label: dp('time') },
+    { key: 'eventType', label: dp('eventType') },
+    { key: 'actor', label: dp('actor') },
+    { key: 'target', label: dp('target') },
+  ];
+
+  return (
+    <main style={{ padding: '1.5rem', fontFamily: 'sans-serif' }}>
+      <div style={{ maxWidth: 1100, margin: '0 auto' }}>
+        <h1 style={{ fontSize: '1.75rem', margin: 0 }}>{t('platformAdminWeb.auditPage.title')}</h1>
+        <p style={{ color: '#475569', marginTop: '0.5rem' }}>{t('platformAdminWeb.auditPage.subtitle')}</p>
+        <PlatformPreviewTable columns={columns} rows={rows} emptyLabel={dp('empty')} />
+      </div>
+    </main>
+  );
 }

--- a/apps/web-platform-admin/app/[locale]/billing/page.tsx
+++ b/apps/web-platform-admin/app/[locale]/billing/page.tsx
@@ -1,11 +1,47 @@
-import { PlatformStubPage } from '@/src/components/PlatformStubPage';
+import { setRequestLocale, getTranslations } from 'next-intl/server';
+import { getPlatformBillingSummary } from '@/src/server/platform/data';
+import { assertPlatformPageAuth } from '@/src/server/platform/page-auth';
 
 type Props = { params: Promise<{ locale: string }> };
 
-export default async function PlatformBillingPage({ params }: Props) {
-  return await PlatformStubPage({
-    params,
-    titleKey: 'platformAdminWeb.billingPage.title',
-    subtitleKey: 'platformAdminWeb.billingPage.subtitle',
-  });
+export default async function BillingPage({ params }: Props) {
+  const { locale } = await params;
+  await assertPlatformPageAuth(locale);
+  setRequestLocale(locale);
+  const t = await getTranslations('common');
+  const dp = (key: string) => t(`platformAdminWeb.dataPreview.${key}`);
+  const summary = await getPlatformBillingSummary();
+
+  const stats = [
+    { label: dp('invoicesTotal'), value: String(summary.invoices_total) },
+    { label: dp('invoicesOpen'), value: String(summary.invoices_open) },
+    { label: dp('invoicesPaid'), value: String(summary.invoices_paid) },
+  ];
+
+  return (
+    <main style={{ padding: '1.5rem', fontFamily: 'sans-serif' }}>
+      <div style={{ maxWidth: 720, margin: '0 auto' }}>
+        <h1 style={{ fontSize: '1.75rem', margin: 0 }}>{t('platformAdminWeb.billingPage.title')}</h1>
+        <p style={{ color: '#475569', marginTop: '0.5rem' }}>{t('platformAdminWeb.billingPage.subtitle')}</p>
+        <dl
+          style={{
+            marginTop: '1.5rem',
+            display: 'grid',
+            gap: '0.75rem',
+            padding: '1rem',
+            border: '1px solid #e2e8f0',
+            borderRadius: 12,
+            background: '#f8fafc',
+          }}
+        >
+          {stats.map((s) => (
+            <div key={s.label} style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem' }}>
+              <dt style={{ color: '#64748b', margin: 0 }}>{s.label}</dt>
+              <dd style={{ margin: 0, fontWeight: 700, color: '#0f172a' }}>{s.value}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </main>
+  );
 }

--- a/apps/web-platform-admin/app/[locale]/cms/page.tsx
+++ b/apps/web-platform-admin/app/[locale]/cms/page.tsx
@@ -1,12 +1,29 @@
-import { PlatformStubPage } from '@/src/components/PlatformStubPage';
+import { setRequestLocale, getTranslations } from 'next-intl/server';
+import { getPlatformConversationsSummary } from '@/src/server/platform/data';
+import { assertPlatformPageAuth } from '@/src/server/platform/page-auth';
 
 type Props = { params: Promise<{ locale: string }> };
 
 export default async function CmsPage({ params }: Props) {
-  return await PlatformStubPage({
-    params,
-    titleKey: 'platformAdminWeb.cmsPage.title',
-    subtitleKey: 'platformAdminWeb.cmsPage.subtitle',
-    bodyKey: 'platformAdminWeb.cmsPage.body',
-  });
+  const { locale } = await params;
+  await assertPlatformPageAuth(locale);
+  setRequestLocale(locale);
+  const t = await getTranslations('common');
+  const dp = (key: string) => t(`platformAdminWeb.dataPreview.${key}`);
+  const { conversations_total } = await getPlatformConversationsSummary();
+
+  return (
+    <main style={{ padding: '1.5rem', fontFamily: 'sans-serif' }}>
+      <div style={{ maxWidth: 720, margin: '0 auto' }}>
+        <h1 style={{ fontSize: '1.75rem', margin: 0 }}>{t('platformAdminWeb.cmsPage.title')}</h1>
+        <p style={{ color: '#475569', marginTop: '0.5rem' }}>{t('platformAdminWeb.cmsPage.subtitle')}</p>
+        <p style={{ color: '#64748b', marginTop: '1rem', whiteSpace: 'pre-line' }}>
+          {t('platformAdminWeb.cmsPage.body')}
+        </p>
+        <p style={{ marginTop: '1.25rem', color: '#0f172a', fontWeight: 600 }}>
+          {dp('cmsStatLabel')}: {conversations_total}
+        </p>
+      </div>
+    </main>
+  );
 }

--- a/apps/web-platform-admin/app/[locale]/gyms/page.tsx
+++ b/apps/web-platform-admin/app/[locale]/gyms/page.tsx
@@ -1,11 +1,45 @@
-import { PlatformStubPage } from '@/src/components/PlatformStubPage';
+import { setRequestLocale, getTranslations } from 'next-intl/server';
+import { PlatformPreviewTable } from '@/src/components/PlatformPreviewTable';
+import { listPlatformGyms } from '@/src/server/platform/data';
+import { assertPlatformPageAuth } from '@/src/server/platform/page-auth';
 
 type Props = { params: Promise<{ locale: string }> };
 
 export default async function GymsPage({ params }: Props) {
-  return await PlatformStubPage({
-    params,
-    titleKey: 'platformAdminWeb.gymsPage.title',
-    subtitleKey: 'platformAdminWeb.gymsPage.subtitle',
-  });
+  const { locale } = await params;
+  await assertPlatformPageAuth(locale);
+  setRequestLocale(locale);
+  const t = await getTranslations('common');
+  const dp = (key: string) => t(`platformAdminWeb.dataPreview.${key}`);
+  const { gyms } = await listPlatformGyms();
+
+  const rows = gyms.map((g) => ({
+    name: g.name,
+    slug: g.slug,
+    active: g.is_active ? dp('yes') : dp('no'),
+    published: g.is_published ? dp('yes') : dp('no'),
+    city: g.city ?? '—',
+    country: g.country ?? '—',
+    created: g.created_at.slice(0, 10),
+  }));
+
+  const columns = [
+    { key: 'name', label: dp('name') },
+    { key: 'slug', label: dp('slug') },
+    { key: 'active', label: dp('active') },
+    { key: 'published', label: dp('published') },
+    { key: 'city', label: dp('city') },
+    { key: 'country', label: dp('country') },
+    { key: 'created', label: dp('createdAt') },
+  ];
+
+  return (
+    <main style={{ padding: '1.5rem', fontFamily: 'sans-serif' }}>
+      <div style={{ maxWidth: 1100, margin: '0 auto' }}>
+        <h1 style={{ fontSize: '1.75rem', margin: 0 }}>{t('platformAdminWeb.gymsPage.title')}</h1>
+        <p style={{ color: '#475569', marginTop: '0.5rem' }}>{t('platformAdminWeb.gymsPage.subtitle')}</p>
+        <PlatformPreviewTable columns={columns} rows={rows} emptyLabel={dp('empty')} />
+      </div>
+    </main>
+  );
 }

--- a/apps/web-platform-admin/app/[locale]/locales/page.tsx
+++ b/apps/web-platform-admin/app/[locale]/locales/page.tsx
@@ -1,11 +1,36 @@
-import { PlatformStubPage } from '@/src/components/PlatformStubPage';
+import { setRequestLocale, getTranslations } from 'next-intl/server';
+import { PlatformPreviewTable } from '@/src/components/PlatformPreviewTable';
+import { getPlatformLocalesSummary } from '@/src/server/platform/data';
+import { assertPlatformPageAuth } from '@/src/server/platform/page-auth';
 
 type Props = { params: Promise<{ locale: string }> };
 
 export default async function LocalesPage({ params }: Props) {
-  return await PlatformStubPage({
-    params,
-    titleKey: 'platformAdminWeb.localesPage.title',
-    subtitleKey: 'platformAdminWeb.localesPage.subtitle',
-  });
+  const { locale } = await params;
+  await assertPlatformPageAuth(locale);
+  setRequestLocale(locale);
+  const t = await getTranslations('common');
+  const dp = (key: string) => t(`platformAdminWeb.dataPreview.${key}`);
+  const { locales } = await getPlatformLocalesSummary();
+
+  const rows = locales.map((row) => ({
+    locale: row.locale,
+    count: String(row.count),
+  }));
+
+  const columnsFixed = [
+    { key: 'locale', label: dp('locale') },
+    { key: 'count', label: t('platformAdminWeb.localesPage.tableCount') },
+  ];
+
+  return (
+    <main style={{ padding: '1.5rem', fontFamily: 'sans-serif' }}>
+      <div style={{ maxWidth: 720, margin: '0 auto' }}>
+        <h1 style={{ fontSize: '1.75rem', margin: 0 }}>{t('platformAdminWeb.localesPage.title')}</h1>
+        <p style={{ color: '#475569', marginTop: '0.5rem' }}>{t('platformAdminWeb.localesPage.subtitle')}</p>
+        <p style={{ color: '#64748b', marginTop: '0.75rem' }}>{dp('localeDistribution')}</p>
+        <PlatformPreviewTable columns={columnsFixed} rows={rows} emptyLabel={dp('empty')} />
+      </div>
+    </main>
+  );
 }

--- a/apps/web-platform-admin/app/[locale]/memberships/page.tsx
+++ b/apps/web-platform-admin/app/[locale]/memberships/page.tsx
@@ -1,12 +1,54 @@
-import { PlatformStubPage } from '@/src/components/PlatformStubPage';
+import { setRequestLocale, getTranslations } from 'next-intl/server';
+import { getPlatformMembershipsSummary } from '@/src/server/platform/data';
+import { assertPlatformPageAuth } from '@/src/server/platform/page-auth';
 
 type Props = { params: Promise<{ locale: string }> };
 
-export default async function MembershipsOversightPage({ params }: Props) {
-  return await PlatformStubPage({
-    params,
-    titleKey: 'platformAdminWeb.membershipsOversightPage.title',
-    subtitleKey: 'platformAdminWeb.membershipsOversightPage.subtitle',
-    bodyKey: 'platformAdminWeb.membershipsOversightPage.body',
-  });
+export default async function MembershipsPage({ params }: Props) {
+  const { locale } = await params;
+  await assertPlatformPageAuth(locale);
+  setRequestLocale(locale);
+  const t = await getTranslations('common');
+  const dp = (key: string) => t(`platformAdminWeb.dataPreview.${key}`);
+  const summary = await getPlatformMembershipsSummary();
+
+  const stats = [
+    { label: dp('instancesTotal'), value: String(summary.instances_total) },
+    { label: dp('instancesActive'), value: String(summary.instances_active) },
+    { label: dp('instancesCancelled'), value: String(summary.instances_cancelled) },
+  ];
+
+  return (
+    <main style={{ padding: '1.5rem', fontFamily: 'sans-serif' }}>
+      <div style={{ maxWidth: 720, margin: '0 auto' }}>
+        <h1 style={{ fontSize: '1.75rem', margin: 0 }}>
+          {t('platformAdminWeb.membershipsOversightPage.title')}
+        </h1>
+        <p style={{ color: '#475569', marginTop: '0.5rem' }}>
+          {t('platformAdminWeb.membershipsOversightPage.subtitle')}
+        </p>
+        <p style={{ color: '#64748b', marginTop: '1rem', whiteSpace: 'pre-line' }}>
+          {t('platformAdminWeb.membershipsOversightPage.body')}
+        </p>
+        <dl
+          style={{
+            marginTop: '1.5rem',
+            display: 'grid',
+            gap: '0.75rem',
+            padding: '1rem',
+            border: '1px solid #e2e8f0',
+            borderRadius: 12,
+            background: '#f8fafc',
+          }}
+        >
+          {stats.map((s) => (
+            <div key={s.label} style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem' }}>
+              <dt style={{ color: '#64748b', margin: 0 }}>{s.label}</dt>
+              <dd style={{ margin: 0, fontWeight: 700, color: '#0f172a' }}>{s.value}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </main>
+  );
 }

--- a/apps/web-platform-admin/app/[locale]/moderation/page.tsx
+++ b/apps/web-platform-admin/app/[locale]/moderation/page.tsx
@@ -1,11 +1,26 @@
-import { PlatformStubPage } from '@/src/components/PlatformStubPage';
+import { setRequestLocale, getTranslations } from 'next-intl/server';
+import { getPlatformConversationsSummary } from '@/src/server/platform/data';
+import { assertPlatformPageAuth } from '@/src/server/platform/page-auth';
 
 type Props = { params: Promise<{ locale: string }> };
 
 export default async function ModerationPage({ params }: Props) {
-  return await PlatformStubPage({
-    params,
-    titleKey: 'platformAdminWeb.moderationPage.title',
-    subtitleKey: 'platformAdminWeb.moderationPage.subtitle',
-  });
+  const { locale } = await params;
+  await assertPlatformPageAuth(locale);
+  setRequestLocale(locale);
+  const t = await getTranslations('common');
+  const dp = (key: string) => t(`platformAdminWeb.dataPreview.${key}`);
+  const { conversations_total } = await getPlatformConversationsSummary();
+
+  return (
+    <main style={{ padding: '1.5rem', fontFamily: 'sans-serif' }}>
+      <div style={{ maxWidth: 720, margin: '0 auto' }}>
+        <h1 style={{ fontSize: '1.75rem', margin: 0 }}>{t('platformAdminWeb.moderationPage.title')}</h1>
+        <p style={{ color: '#475569', marginTop: '0.5rem' }}>{t('platformAdminWeb.moderationPage.subtitle')}</p>
+        <p style={{ marginTop: '1.25rem', color: '#0f172a', fontWeight: 600 }}>
+          {dp('moderationSummary')}: {conversations_total}
+        </p>
+      </div>
+    </main>
+  );
 }

--- a/apps/web-platform-admin/app/[locale]/support/page.tsx
+++ b/apps/web-platform-admin/app/[locale]/support/page.tsx
@@ -1,11 +1,26 @@
-import { PlatformStubPage } from '@/src/components/PlatformStubPage';
+import { setRequestLocale, getTranslations } from 'next-intl/server';
+import { getPlatformConversationsSummary } from '@/src/server/platform/data';
+import { assertPlatformPageAuth } from '@/src/server/platform/page-auth';
 
 type Props = { params: Promise<{ locale: string }> };
 
 export default async function SupportPage({ params }: Props) {
-  return await PlatformStubPage({
-    params,
-    titleKey: 'platformAdminWeb.supportPage.title',
-    subtitleKey: 'platformAdminWeb.supportPage.subtitle',
-  });
+  const { locale } = await params;
+  await assertPlatformPageAuth(locale);
+  setRequestLocale(locale);
+  const t = await getTranslations('common');
+  const dp = (key: string) => t(`platformAdminWeb.dataPreview.${key}`);
+  const { conversations_total } = await getPlatformConversationsSummary();
+
+  return (
+    <main style={{ padding: '1.5rem', fontFamily: 'sans-serif' }}>
+      <div style={{ maxWidth: 720, margin: '0 auto' }}>
+        <h1 style={{ fontSize: '1.75rem', margin: 0 }}>{t('platformAdminWeb.supportPage.title')}</h1>
+        <p style={{ color: '#475569', marginTop: '0.5rem' }}>{t('platformAdminWeb.supportPage.subtitle')}</p>
+        <p style={{ marginTop: '1.25rem', color: '#0f172a', fontWeight: 600 }}>
+          {dp('supportSummary')}: {conversations_total}
+        </p>
+      </div>
+    </main>
+  );
 }

--- a/apps/web-platform-admin/app/[locale]/users/page.tsx
+++ b/apps/web-platform-admin/app/[locale]/users/page.tsx
@@ -1,11 +1,39 @@
-import { PlatformStubPage } from '@/src/components/PlatformStubPage';
+import { setRequestLocale, getTranslations } from 'next-intl/server';
+import { PlatformPreviewTable } from '@/src/components/PlatformPreviewTable';
+import { listPlatformUsersWithRoles } from '@/src/server/platform/data';
+import { assertPlatformPageAuth } from '@/src/server/platform/page-auth';
 
 type Props = { params: Promise<{ locale: string }> };
 
 export default async function UsersPage({ params }: Props) {
-  return await PlatformStubPage({
-    params,
-    titleKey: 'platformAdminWeb.usersPage.title',
-    subtitleKey: 'platformAdminWeb.usersPage.subtitle',
-  });
+  const { locale } = await params;
+  await assertPlatformPageAuth(locale);
+  setRequestLocale(locale);
+  const t = await getTranslations('common');
+  const dp = (key: string) => t(`platformAdminWeb.dataPreview.${key}`);
+  const { users } = await listPlatformUsersWithRoles();
+
+  const rows = users.map((u) => ({
+    displayName: u.display_name,
+    userId: u.user_id,
+    locale: u.locale,
+    roles: u.roles.map((r) => `${r.role}${r.gym_id ? ` @ ${r.gym_id.slice(0, 8)}…` : ''}`).join('; ') || '—',
+  }));
+
+  const columns = [
+    { key: 'displayName', label: dp('displayName') },
+    { key: 'userId', label: dp('userId') },
+    { key: 'locale', label: dp('locale') },
+    { key: 'roles', label: dp('roles') },
+  ];
+
+  return (
+    <main style={{ padding: '1.5rem', fontFamily: 'sans-serif' }}>
+      <div style={{ maxWidth: 1100, margin: '0 auto' }}>
+        <h1 style={{ fontSize: '1.75rem', margin: 0 }}>{t('platformAdminWeb.usersPage.title')}</h1>
+        <p style={{ color: '#475569', marginTop: '0.5rem' }}>{t('platformAdminWeb.usersPage.subtitle')}</p>
+        <PlatformPreviewTable columns={columns} rows={rows} emptyLabel={dp('empty')} />
+      </div>
+    </main>
+  );
 }

--- a/apps/web-platform-admin/app/api/v1/platform/audit-events/route.ts
+++ b/apps/web-platform-admin/app/api/v1/platform/audit-events/route.ts
@@ -1,0 +1,20 @@
+import { platformAuditListResponseSchema } from '@myclup/contracts';
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { listRecentAuditEvents } from '@/src/server/platform/data';
+import { requirePlatformOperator } from '@/src/server/platform/gate';
+
+export async function GET(request: NextRequest) {
+  const gate = await requirePlatformOperator(request);
+  if (!gate.ok) {
+    return NextResponse.json({ error: gate.error }, { status: gate.status });
+  }
+
+  const data = await listRecentAuditEvents();
+  const parsed = platformAuditListResponseSchema.safeParse(data);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'internal_error' }, { status: 500 });
+  }
+
+  return NextResponse.json(parsed.data);
+}

--- a/apps/web-platform-admin/app/api/v1/platform/billing-summary/route.ts
+++ b/apps/web-platform-admin/app/api/v1/platform/billing-summary/route.ts
@@ -1,0 +1,20 @@
+import { platformBillingSummaryResponseSchema } from '@myclup/contracts';
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { getPlatformBillingSummary } from '@/src/server/platform/data';
+import { requirePlatformOperator } from '@/src/server/platform/gate';
+
+export async function GET(request: NextRequest) {
+  const gate = await requirePlatformOperator(request);
+  if (!gate.ok) {
+    return NextResponse.json({ error: gate.error }, { status: gate.status });
+  }
+
+  const data = await getPlatformBillingSummary();
+  const parsed = platformBillingSummaryResponseSchema.safeParse(data);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'internal_error' }, { status: 500 });
+  }
+
+  return NextResponse.json(parsed.data);
+}

--- a/apps/web-platform-admin/app/api/v1/platform/conversations-summary/route.ts
+++ b/apps/web-platform-admin/app/api/v1/platform/conversations-summary/route.ts
@@ -1,0 +1,20 @@
+import { platformConversationsSummaryResponseSchema } from '@myclup/contracts';
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { getPlatformConversationsSummary } from '@/src/server/platform/data';
+import { requirePlatformOperator } from '@/src/server/platform/gate';
+
+export async function GET(request: NextRequest) {
+  const gate = await requirePlatformOperator(request);
+  if (!gate.ok) {
+    return NextResponse.json({ error: gate.error }, { status: gate.status });
+  }
+
+  const data = await getPlatformConversationsSummary();
+  const parsed = platformConversationsSummaryResponseSchema.safeParse(data);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'internal_error' }, { status: 500 });
+  }
+
+  return NextResponse.json(parsed.data);
+}

--- a/apps/web-platform-admin/app/api/v1/platform/gyms/route.test.ts
+++ b/apps/web-platform-admin/app/api/v1/platform/gyms/route.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { platformGymsListResponseSchema } from '@myclup/contracts';
+import { GET } from './route';
+
+vi.mock('@/src/server/platform/gate', () => ({
+  requirePlatformOperator: vi.fn(),
+}));
+
+vi.mock('@/src/server/platform/data', () => ({
+  listPlatformGyms: vi.fn(),
+}));
+
+import { requirePlatformOperator } from '@/src/server/platform/gate';
+import { listPlatformGyms } from '@/src/server/platform/data';
+
+const mockGate = vi.mocked(requirePlatformOperator);
+const mockList = vi.mocked(listPlatformGyms);
+
+describe('GET /api/v1/platform/gyms', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when gate fails', async () => {
+    mockGate.mockResolvedValue({ ok: false, status: 401, error: 'unauthorized' });
+    const req = new NextRequest('http://localhost:3002/api/v1/platform/gyms');
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns validated gym list when authorized', async () => {
+    mockGate.mockResolvedValue({ ok: true, userId: '00000000-0000-4000-8000-000000000099' });
+    mockList.mockResolvedValue({
+      gyms: [
+        {
+          id: '00000000-0000-4000-8000-000000000001',
+          name: 'Gym A',
+          slug: 'gym-a',
+          is_active: true,
+          is_published: true,
+          city: null,
+          country: null,
+          created_at: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const req = new NextRequest('http://localhost:3002/api/v1/platform/gyms');
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as unknown;
+    const parsed = platformGymsListResponseSchema.safeParse(json);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.gyms).toHaveLength(1);
+      expect(parsed.data.gyms[0].slug).toBe('gym-a');
+    }
+  });
+});

--- a/apps/web-platform-admin/app/api/v1/platform/gyms/route.ts
+++ b/apps/web-platform-admin/app/api/v1/platform/gyms/route.ts
@@ -1,0 +1,20 @@
+import { platformGymsListResponseSchema } from '@myclup/contracts';
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { listPlatformGyms } from '@/src/server/platform/data';
+import { requirePlatformOperator } from '@/src/server/platform/gate';
+
+export async function GET(request: NextRequest) {
+  const gate = await requirePlatformOperator(request);
+  if (!gate.ok) {
+    return NextResponse.json({ error: gate.error }, { status: gate.status });
+  }
+
+  const data = await listPlatformGyms();
+  const parsed = platformGymsListResponseSchema.safeParse(data);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'internal_error' }, { status: 500 });
+  }
+
+  return NextResponse.json(parsed.data);
+}

--- a/apps/web-platform-admin/app/api/v1/platform/locales-summary/route.ts
+++ b/apps/web-platform-admin/app/api/v1/platform/locales-summary/route.ts
@@ -1,0 +1,20 @@
+import { platformLocalesSummaryResponseSchema } from '@myclup/contracts';
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { getPlatformLocalesSummary } from '@/src/server/platform/data';
+import { requirePlatformOperator } from '@/src/server/platform/gate';
+
+export async function GET(request: NextRequest) {
+  const gate = await requirePlatformOperator(request);
+  if (!gate.ok) {
+    return NextResponse.json({ error: gate.error }, { status: gate.status });
+  }
+
+  const data = await getPlatformLocalesSummary();
+  const parsed = platformLocalesSummaryResponseSchema.safeParse(data);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'internal_error' }, { status: 500 });
+  }
+
+  return NextResponse.json(parsed.data);
+}

--- a/apps/web-platform-admin/app/api/v1/platform/memberships-summary/route.ts
+++ b/apps/web-platform-admin/app/api/v1/platform/memberships-summary/route.ts
@@ -1,0 +1,20 @@
+import { platformMembershipsSummaryResponseSchema } from '@myclup/contracts';
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { getPlatformMembershipsSummary } from '@/src/server/platform/data';
+import { requirePlatformOperator } from '@/src/server/platform/gate';
+
+export async function GET(request: NextRequest) {
+  const gate = await requirePlatformOperator(request);
+  if (!gate.ok) {
+    return NextResponse.json({ error: gate.error }, { status: gate.status });
+  }
+
+  const data = await getPlatformMembershipsSummary();
+  const parsed = platformMembershipsSummaryResponseSchema.safeParse(data);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'internal_error' }, { status: 500 });
+  }
+
+  return NextResponse.json(parsed.data);
+}

--- a/apps/web-platform-admin/app/api/v1/platform/users/route.ts
+++ b/apps/web-platform-admin/app/api/v1/platform/users/route.ts
@@ -1,0 +1,20 @@
+import { platformUsersListResponseSchema } from '@myclup/contracts';
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { listPlatformUsersWithRoles } from '@/src/server/platform/data';
+import { requirePlatformOperator } from '@/src/server/platform/gate';
+
+export async function GET(request: NextRequest) {
+  const gate = await requirePlatformOperator(request);
+  if (!gate.ok) {
+    return NextResponse.json({ error: gate.error }, { status: gate.status });
+  }
+
+  const data = await listPlatformUsersWithRoles();
+  const parsed = platformUsersListResponseSchema.safeParse(data);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'internal_error' }, { status: 500 });
+  }
+
+  return NextResponse.json(parsed.data);
+}

--- a/apps/web-platform-admin/src/components/PlatformPreviewTable.tsx
+++ b/apps/web-platform-admin/src/components/PlatformPreviewTable.tsx
@@ -1,0 +1,50 @@
+type Column = { key: string; label: string };
+
+type Props = {
+  columns: Column[];
+  rows: Record<string, string>[];
+  emptyLabel: string;
+};
+
+export function PlatformPreviewTable({ columns, rows, emptyLabel }: Props) {
+  if (rows.length === 0) {
+    return (
+      <p style={{ color: '#64748b', marginTop: '1.25rem' }} data-testid="platform-table-empty">
+        {emptyLabel}
+      </p>
+    );
+  }
+
+  return (
+    <div style={{ marginTop: '1.25rem', overflowX: 'auto' }}>
+      <table
+        style={{
+          width: '100%',
+          borderCollapse: 'collapse',
+          fontSize: '0.9rem',
+        }}
+      >
+        <thead>
+          <tr style={{ borderBottom: '1px solid #e2e8f0', textAlign: 'left' }}>
+            {columns.map((c) => (
+              <th key={c.key} style={{ padding: '0.5rem 0.75rem', color: '#475569' }}>
+                {c.label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, i) => (
+            <tr key={i} style={{ borderBottom: '1px solid #f1f5f9' }}>
+              {columns.map((c) => (
+                <td key={c.key} style={{ padding: '0.5rem 0.75rem', color: '#0f172a' }}>
+                  {row[c.key] ?? '—'}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web-platform-admin/src/server/platform/data.ts
+++ b/apps/web-platform-admin/src/server/platform/data.ts
@@ -1,0 +1,181 @@
+/**
+ * Platform-wide read models (service role). Caller must enforce requirePlatformOperator first.
+ */
+import type {
+  PlatformAuditListResponse,
+  PlatformBillingSummaryResponse,
+  PlatformConversationsSummaryResponse,
+  PlatformGymsListResponse,
+  PlatformLocalesSummaryResponse,
+  PlatformMembershipsSummaryResponse,
+  PlatformUsersListResponse,
+} from '@myclup/contracts';
+import { getPlatformServiceClient } from '@/src/server/platform/service-client';
+
+function emptyGyms(): PlatformGymsListResponse {
+  return { gyms: [] };
+}
+
+export async function listPlatformGyms(): Promise<PlatformGymsListResponse> {
+  const service = getPlatformServiceClient();
+  if (!service) return emptyGyms();
+
+  const { data, error } = await service
+    .from('gyms')
+    .select('id, name, slug, is_active, is_published, city, country, created_at')
+    .order('name', { ascending: true })
+    .limit(200);
+
+  if (error || !data) return emptyGyms();
+
+  return {
+    gyms: data.map((g) => ({
+      id: g.id,
+      name: g.name,
+      slug: g.slug,
+      is_active: g.is_active,
+      is_published: g.is_published,
+      city: g.city,
+      country: g.country,
+      created_at: g.created_at,
+    })),
+  };
+}
+
+export async function listPlatformUsersWithRoles(): Promise<PlatformUsersListResponse> {
+  const service = getPlatformServiceClient();
+  if (!service) return { users: [] };
+
+  const { data: profiles, error: pErr } = await service
+    .from('profiles')
+    .select('user_id, display_name, locale')
+    .order('display_name', { ascending: true })
+    .limit(200);
+
+  if (pErr || !profiles?.length) return { users: [] };
+
+  const ids = profiles.map((p) => p.user_id);
+  const { data: roles, error: rErr } = await service
+    .from('user_role_assignments')
+    .select('user_id, role, gym_id')
+    .in('user_id', ids);
+
+  if (rErr) return { users: [] };
+
+  const byUser = new Map<string, { role: string; gym_id: string | null }[]>();
+  for (const row of roles ?? []) {
+    const list = byUser.get(row.user_id) ?? [];
+    list.push({ role: row.role, gym_id: row.gym_id });
+    byUser.set(row.user_id, list);
+  }
+
+  return {
+    users: profiles.map((p) => ({
+      user_id: p.user_id,
+      display_name: p.display_name,
+      locale: p.locale,
+      roles: byUser.get(p.user_id) ?? [],
+    })),
+  };
+}
+
+export async function listRecentAuditEvents(): Promise<PlatformAuditListResponse> {
+  const service = getPlatformServiceClient();
+  if (!service) return { events: [] };
+
+  const { data, error } = await service
+    .from('audit_events')
+    .select('id, event_type, actor_id, target_type, target_id, created_at')
+    .order('created_at', { ascending: false })
+    .limit(100);
+
+  if (error || !data) return { events: [] };
+
+  return {
+    events: data.map((e) => ({
+      id: e.id,
+      event_type: e.event_type,
+      actor_id: e.actor_id,
+      target_type: e.target_type,
+      target_id: e.target_id,
+      created_at: e.created_at,
+    })),
+  };
+}
+
+async function countWhere(
+  table: 'invoices' | 'membership_instances' | 'conversations',
+  filter?: { column: string; value: string },
+): Promise<number> {
+  const service = getPlatformServiceClient();
+  if (!service) return 0;
+  let q = service.from(table).select('*', { count: 'exact', head: true });
+  if (filter) {
+    q = q.eq(filter.column, filter.value);
+  }
+  const { count, error } = await q;
+  if (error || count === null) return 0;
+  return count;
+}
+
+export async function getPlatformBillingSummary(): Promise<PlatformBillingSummaryResponse> {
+  const service = getPlatformServiceClient();
+  if (!service) {
+    return { invoices_total: 0, invoices_open: 0, invoices_paid: 0 };
+  }
+
+  const total = await countWhere('invoices');
+  const open = await countWhere('invoices', { column: 'status', value: 'open' });
+  const paid = await countWhere('invoices', { column: 'status', value: 'paid' });
+
+  return {
+    invoices_total: total,
+    invoices_open: open,
+    invoices_paid: paid,
+  };
+}
+
+export async function getPlatformMembershipsSummary(): Promise<PlatformMembershipsSummaryResponse> {
+  const service = getPlatformServiceClient();
+  if (!service) {
+    return { instances_total: 0, instances_active: 0, instances_cancelled: 0 };
+  }
+
+  const total = await countWhere('membership_instances');
+  const active = await countWhere('membership_instances', { column: 'status', value: 'active' });
+  const cancelled = await countWhere('membership_instances', {
+    column: 'status',
+    value: 'cancelled',
+  });
+
+  return {
+    instances_total: total,
+    instances_active: active,
+    instances_cancelled: cancelled,
+  };
+}
+
+export async function getPlatformLocalesSummary(): Promise<PlatformLocalesSummaryResponse> {
+  const service = getPlatformServiceClient();
+  if (!service) return { locales: [] };
+
+  const { data, error } = await service.from('profiles').select('locale').limit(2000);
+
+  if (error || !data) return { locales: [] };
+
+  const counts = new Map<string, number>();
+  for (const row of data) {
+    counts.set(row.locale, (counts.get(row.locale) ?? 0) + 1);
+  }
+
+  return {
+    locales: [...counts.entries()]
+      .map(([locale, count]) => ({ locale, count }))
+      .sort((a, b) => b.count - a.count),
+  };
+}
+
+export async function getPlatformConversationsSummary(): Promise<PlatformConversationsSummaryResponse> {
+  const total = await countWhere('conversations');
+  return { conversations_total: total };
+}

--- a/apps/web-platform-admin/src/server/platform/gate.ts
+++ b/apps/web-platform-admin/src/server/platform/gate.ts
@@ -1,0 +1,46 @@
+/**
+ * Platform BFF gate: validated session + platform role check (server-only).
+ */
+import { getSession } from '@myclup/supabase';
+import { getPlatformServiceClient } from '@/src/server/platform/service-client';
+
+const PLATFORM_ROLES = new Set(['platform_admin', 'platform_support', 'platform_finance']);
+
+export type PlatformGate =
+  | { ok: true; userId: string }
+  | { ok: false; status: 401 | 403; error: string };
+
+type HeaderCarrier = { headers: Headers };
+
+export async function requirePlatformOperator(req: HeaderCarrier): Promise<PlatformGate> {
+  const session = await getSession(req);
+  const userId = session?.user?.id;
+  if (!userId) {
+    return { ok: false, status: 401, error: 'unauthorized' };
+  }
+
+  const service = getPlatformServiceClient();
+  if (!service) {
+    // Tests / misconfig: mirror sign-in leniency — still require a session
+    return { ok: true, userId };
+  }
+
+  const { data: roleRows, error } = await service
+    .from('user_role_assignments')
+    .select('role, gym_id')
+    .eq('user_id', userId);
+
+  if (error) {
+    return { ok: false, status: 403, error: 'forbidden' };
+  }
+
+  const hasPlatform = (roleRows ?? []).some(
+    (row) => row.gym_id === null && PLATFORM_ROLES.has(row.role),
+  );
+
+  if (!hasPlatform) {
+    return { ok: false, status: 403, error: 'forbidden' };
+  }
+
+  return { ok: true, userId };
+}

--- a/apps/web-platform-admin/src/server/platform/page-auth.ts
+++ b/apps/web-platform-admin/src/server/platform/page-auth.ts
@@ -1,0 +1,12 @@
+import { headers } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { requirePlatformOperator } from '@/src/server/platform/gate';
+
+/** Ensures the current request has a platform role; otherwise redirects to sign-in. */
+export async function assertPlatformPageAuth(locale: string): Promise<void> {
+  const h = await headers();
+  const gate = await requirePlatformOperator({ headers: h });
+  if (!gate.ok) {
+    redirect(`/${locale}/sign-in`);
+  }
+}

--- a/apps/web-platform-admin/src/server/platform/service-client.ts
+++ b/apps/web-platform-admin/src/server/platform/service-client.ts
@@ -1,0 +1,12 @@
+import { createServerClient } from '@myclup/supabase';
+import type { ServerSupabaseClient } from '@myclup/supabase';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+
+export function getPlatformServiceClient(): ServerSupabaseClient | null {
+  if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
+    return null;
+  }
+  return createServerClient({ supabaseUrl: SUPABASE_URL, serviceRoleKey: SERVICE_ROLE_KEY });
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -16,4 +16,5 @@ export * from './listing';
 export * from './locale';
 export * from './members';
 export * from './membership';
+export * from './platform';
 export * from './reports';

--- a/packages/contracts/src/platform/index.ts
+++ b/packages/contracts/src/platform/index.ts
@@ -1,0 +1,1 @@
+export * from './schemas';

--- a/packages/contracts/src/platform/schemas.test.ts
+++ b/packages/contracts/src/platform/schemas.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { platformGymsListResponseSchema, platformGymRowSchema } from './schemas';
+
+describe('platform schemas', () => {
+  it('accepts a minimal gyms list response', () => {
+    const row = {
+      id: '00000000-0000-4000-8000-000000000001',
+      name: 'Test Gym',
+      slug: 'test-gym',
+      is_active: true,
+      is_published: false,
+      city: 'Istanbul',
+      country: 'TR',
+      created_at: '2026-01-01T00:00:00.000Z',
+    };
+    expect(platformGymRowSchema.safeParse(row).success).toBe(true);
+    const parsed = platformGymsListResponseSchema.safeParse({ gyms: [row] });
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/packages/contracts/src/platform/schemas.ts
+++ b/packages/contracts/src/platform/schemas.ts
@@ -1,0 +1,78 @@
+import { z } from 'zod';
+
+export const platformGymRowSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  slug: z.string(),
+  is_active: z.boolean(),
+  is_published: z.boolean(),
+  city: z.string().nullable(),
+  country: z.string().nullable(),
+  created_at: z.string(),
+});
+
+export const platformGymsListResponseSchema = z.object({
+  gyms: z.array(platformGymRowSchema),
+});
+
+export const platformUserRoleRowSchema = z.object({
+  role: z.string(),
+  gym_id: z.string().uuid().nullable(),
+});
+
+export const platformUserRowSchema = z.object({
+  user_id: z.string().uuid(),
+  display_name: z.string(),
+  locale: z.string(),
+  roles: z.array(platformUserRoleRowSchema),
+});
+
+export const platformUsersListResponseSchema = z.object({
+  users: z.array(platformUserRowSchema),
+});
+
+export const platformAuditRowSchema = z.object({
+  id: z.string().uuid(),
+  event_type: z.string(),
+  actor_id: z.string().uuid().nullable(),
+  target_type: z.string(),
+  target_id: z.string().nullable(),
+  created_at: z.string(),
+});
+
+export const platformAuditListResponseSchema = z.object({
+  events: z.array(platformAuditRowSchema),
+});
+
+export const platformBillingSummaryResponseSchema = z.object({
+  invoices_total: z.number().int().nonnegative(),
+  invoices_open: z.number().int().nonnegative(),
+  invoices_paid: z.number().int().nonnegative(),
+});
+
+export const platformMembershipsSummaryResponseSchema = z.object({
+  instances_total: z.number().int().nonnegative(),
+  instances_active: z.number().int().nonnegative(),
+  instances_cancelled: z.number().int().nonnegative(),
+});
+
+export const platformLocaleStatSchema = z.object({
+  locale: z.string(),
+  count: z.number().int().nonnegative(),
+});
+
+export const platformLocalesSummaryResponseSchema = z.object({
+  locales: z.array(platformLocaleStatSchema),
+});
+
+export const platformConversationsSummaryResponseSchema = z.object({
+  conversations_total: z.number().int().nonnegative(),
+});
+
+export type PlatformGymsListResponse = z.infer<typeof platformGymsListResponseSchema>;
+export type PlatformUsersListResponse = z.infer<typeof platformUsersListResponseSchema>;
+export type PlatformAuditListResponse = z.infer<typeof platformAuditListResponseSchema>;
+export type PlatformBillingSummaryResponse = z.infer<typeof platformBillingSummaryResponseSchema>;
+export type PlatformMembershipsSummaryResponse = z.infer<typeof platformMembershipsSummaryResponseSchema>;
+export type PlatformLocalesSummaryResponse = z.infer<typeof platformLocalesSummaryResponseSchema>;
+export type PlatformConversationsSummaryResponse = z.infer<typeof platformConversationsSummaryResponseSchema>;

--- a/packages/i18n/src/namespaces/common/en.json
+++ b/packages/i18n/src/namespaces/common/en.json
@@ -482,6 +482,37 @@
     "dashboardTitle": "Platform dashboard",
     "dashboardSubtitle": "Cross-tenant oversight, support tooling, and governance. Wire this app to the shared BFF via NEXT_PUBLIC_BFF_BASE_URL when API routes are mounted here.",
     "metricsPlaceholder": "Operational KPIs will aggregate tenant-safe metrics once reporting endpoints are connected.",
+    "dataPreview": {
+      "empty": "No rows to display. With a local Supabase service role, this view loads tenant-safe read models.",
+      "yes": "Yes",
+      "no": "No",
+      "name": "Name",
+      "slug": "Slug",
+      "active": "Active",
+      "published": "Listed",
+      "city": "City",
+      "country": "Country",
+      "createdAt": "Created",
+      "userId": "User ID",
+      "displayName": "Display name",
+      "locale": "Locale",
+      "roles": "Roles",
+      "eventType": "Event",
+      "actor": "Actor",
+      "target": "Target",
+      "time": "Time",
+      "invoicesTotal": "Invoices (total)",
+      "invoicesOpen": "Open invoices",
+      "invoicesPaid": "Paid invoices",
+      "instancesTotal": "Membership instances",
+      "instancesActive": "Active",
+      "instancesCancelled": "Cancelled",
+      "conversationsTotal": "Conversations",
+      "localeDistribution": "Profile locale distribution",
+      "cmsStatLabel": "Conversations (content/support volume indicator)",
+      "supportSummary": "Total conversations (support queue indicator)",
+      "moderationSummary": "Total conversations (moderation scope indicator)"
+    },
     "sidebar": {
       "dashboard": "Dashboard",
       "gyms": "Gyms & tenants",
@@ -526,7 +557,8 @@
     },
     "localesPage": {
       "title": "Localization operations",
-      "subtitle": "Coordinate default locales, fallbacks, and translation coverage."
+      "subtitle": "Coordinate default locales, fallbacks, and translation coverage.",
+      "tableCount": "Profiles"
     },
     "auditPage": {
       "title": "Audit log",

--- a/packages/i18n/src/namespaces/common/tr.json
+++ b/packages/i18n/src/namespaces/common/tr.json
@@ -482,6 +482,37 @@
     "dashboardTitle": "Platform paneli",
     "dashboardSubtitle": "Kiracılar arası gözetim, destek araçları ve yönetişim. API rotaları buraya taşındığında paylaşılan BFF için NEXT_PUBLIC_BFF_BASE_URL kullanın.",
     "metricsPlaceholder": "Raporlama uçları bağlandığında operasyonel KPI’lar kiracı güvenli şekilde toplanacak.",
+    "dataPreview": {
+      "empty": "Gösterilecek satır yok. Yerel Supabase service role ile bu görünüm kiracı güvenli okuma modellerini yükler.",
+      "yes": "Evet",
+      "no": "Hayır",
+      "name": "Ad",
+      "slug": "Kısa ad",
+      "active": "Aktif",
+      "published": "Listelenen",
+      "city": "Şehir",
+      "country": "Ülke",
+      "createdAt": "Oluşturulma",
+      "userId": "Kullanıcı ID",
+      "displayName": "Görünen ad",
+      "locale": "Dil",
+      "roles": "Roller",
+      "eventType": "Olay",
+      "actor": "Aktör",
+      "target": "Hedef",
+      "time": "Zaman",
+      "invoicesTotal": "Faturalar (toplam)",
+      "invoicesOpen": "Açık faturalar",
+      "invoicesPaid": "Ödenen faturalar",
+      "instancesTotal": "Üyelik örnekleri",
+      "instancesActive": "Aktif",
+      "instancesCancelled": "İptal",
+      "conversationsTotal": "Konuşmalar",
+      "localeDistribution": "Profil dil dağılımı",
+      "cmsStatLabel": "Konuşmalar (içerik/destek hacim göstergesi)",
+      "supportSummary": "Toplam konuşmalar (destek kuyruğu göstergesi)",
+      "moderationSummary": "Toplam konuşmalar (moderasyon kapsamı göstergesi)"
+    },
     "sidebar": {
       "dashboard": "Panel",
       "gyms": "Salonlar ve kiracılar",
@@ -526,7 +557,8 @@
     },
     "localesPage": {
       "title": "Yerelleştirme işlemleri",
-      "subtitle": "Varsayılan diller, geri dönüşler ve çeviri kapsamını koordine edin."
+      "subtitle": "Varsayılan diller, geri dönüşler ve çeviri kapsamını koordine edin.",
+      "tableCount": "Profiller"
     },
     "auditPage": {
       "title": "Denetim günlüğü",


### PR DESCRIPTION
## Summary
Implements Dalga 2 of the delivery plan: platform admin read models behind authenticated platform-role gate, shared Zod contracts, and localized data previews for Tasks 33.1–33.8 scope.

## Closes
Closes #229
Closes #230
Closes #231
Closes #232
Closes #233
Closes #234
Closes #235

## Epic
Part of Epic #33 (Platform Admin Web MVP).

## Acceptance
- [x] Contracts in `packages/contracts` for platform list/summary responses
- [x] BFF GET `/api/v1/platform/*` with session + platform role enforcement
- [x] RSC pages load read models (service role) after `assertPlatformPageAuth`
- [x] i18n: `platformAdminWeb.dataPreview` + `localesPage.tableCount` (en/tr parity)
- [x] Tests: `app/api/v1/platform/gyms/route.test.ts`

## Validation
```bash
pnpm --filter @myclup/contracts build test
pnpm --filter @myclup/web-platform-admin test
pnpm --filter @myclup/i18n test
pnpm test
```
All passed locally.

Made with [Cursor](https://cursor.com)