### PR TITLE
feat(issue-241): web site contact lead persistence

### DIFF
--- a/apps/web-site/package.json
+++ b/apps/web-site/package.json
@@ -12,12 +12,15 @@
   },
   "dependencies": {
     "@myclup/analytics": "workspace:*",
+    "@myclup/contracts": "workspace:*",
     "@myclup/i18n": "workspace:*",
+    "@myclup/supabase": "workspace:*",
     "@myclup/types": "workspace:*",
     "next": "^15.1.0",
     "next-intl": "^3.25.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",

--- a/apps/web-site/src/app/api/v1/public/contact-leads/route.test.ts
+++ b/apps/web-site/src/app/api/v1/public/contact-leads/route.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { contactLeadResponseSchema } from '@myclup/contracts';
+import { POST } from './route';
+
+vi.mock('@/server/contact-lead', () => ({
+  persistContactLead: vi.fn(),
+}));
+
+import { persistContactLead } from '@/server/contact-lead';
+
+const mockPersist = vi.mocked(persistContactLead);
+
+describe('POST /api/v1/public/contact-leads', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 200 and contract body when persist succeeds', async () => {
+    mockPersist.mockResolvedValue({
+      ok: true,
+      id: '00000000-0000-4000-8000-000000000001',
+    });
+
+    const req = new NextRequest('http://localhost:3000/api/v1/public/contact-leads', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Ada',
+        email: 'ada@example.com',
+        message: 'Hi',
+        locale: 'en',
+      }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as unknown;
+    const parsed = contactLeadResponseSchema.safeParse(json);
+    expect(parsed.success).toBe(true);
+    if (parsed.success && parsed.data.ok) {
+      expect(parsed.data.id).toBe('00000000-0000-4000-8000-000000000001');
+    }
+  });
+
+  it('returns 400 when body invalid', async () => {
+    const req = new NextRequest('http://localhost:3000/api/v1/public/contact-leads', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'bad' }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect(mockPersist).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web-site/src/app/api/v1/public/contact-leads/route.ts
+++ b/apps/web-site/src/app/api/v1/public/contact-leads/route.ts
@@ -1,0 +1,11 @@
+import type { ContactLeadRequest } from '@myclup/contracts';
+import { contactLeadContract } from '@myclup/contracts';
+import * as contactLeadServer from '@/server/contact-lead';
+import { withContractRoute } from '@/lib/withContractRoute';
+
+export const POST = withContractRoute(contactLeadContract, async (body) => {
+  if (!body) {
+    return { ok: false as const, error: 'validation_error' };
+  }
+  return contactLeadServer.persistContactLead(body as ContactLeadRequest);
+});

--- a/apps/web-site/src/components/LeadCaptureForm.test.tsx
+++ b/apps/web-site/src/components/LeadCaptureForm.test.tsx
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { NextIntlClientProvider } from 'next-intl';
 import { LeadCaptureForm } from './LeadCaptureForm';
 
@@ -11,24 +11,37 @@ const messages = {
         email: 'Email',
         message: 'Message',
         submit: 'Send message',
+        submitting: 'Sending…',
         thanks: 'Thanks for reaching out',
+        errorSubmit: 'Could not send',
       },
     },
   },
 };
 
 describe('LeadCaptureForm', () => {
-  it('shows thanks after submit', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows thanks after successful submit', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true, id: '00000000-0000-4000-8000-000000000001' }),
+    }) as unknown as typeof fetch;
+
     render(
       <NextIntlClientProvider locale="en" messages={messages}>
         <LeadCaptureForm />
-      </NextIntlClientProvider>
+      </NextIntlClientProvider>,
     );
 
     fireEvent.change(screen.getByLabelText(/^Name$/), { target: { value: 'Test User' } });
     fireEvent.change(screen.getByLabelText(/^Email$/), { target: { value: 'test@example.com' } });
     fireEvent.click(screen.getByRole('button', { name: /send message/i }));
 
-    expect(screen.getByText(/thanks for reaching out/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(/thanks for reaching out/i)).toBeInTheDocument();
+    });
   });
 });

--- a/apps/web-site/src/components/LeadCaptureForm.tsx
+++ b/apps/web-site/src/components/LeadCaptureForm.tsx
@@ -15,17 +15,42 @@ export function LeadCaptureForm() {
   const [email, setEmail] = useState('');
   const [message, setMessage] = useState('');
   const [sent, setSent] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
 
-  const onSubmit = (e: FormEvent) => {
+  const onSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    const analytics = createNoopAnalyticsEmitter();
-    analytics.track(McGa4Event.marketing_lead_submit, {
-      schema_version: ANALYTICS_SCHEMA_VERSION,
-      surface: 'web_site',
-      locale,
-      has_message: Boolean(message.trim()),
-    });
-    setSent(true);
+    setSubmitError(null);
+    setSubmitting(true);
+    try {
+      const res = await fetch('/api/v1/public/contact-leads', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: name.trim(),
+          email: email.trim(),
+          message: message.trim(),
+          locale,
+        }),
+      });
+      const data = (await res.json()) as { ok?: boolean; error?: string };
+      if (!res.ok || data.ok !== true) {
+        setSubmitError(t('publicSite.lead.errorSubmit'));
+        return;
+      }
+      const analytics = createNoopAnalyticsEmitter();
+      analytics.track(McGa4Event.marketing_lead_submit, {
+        schema_version: ANALYTICS_SCHEMA_VERSION,
+        surface: 'web_site',
+        locale,
+        has_message: Boolean(message.trim()),
+      });
+      setSent(true);
+    } catch {
+      setSubmitError(t('publicSite.lead.errorSubmit'));
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   if (sent) {
@@ -66,11 +91,17 @@ export function LeadCaptureForm() {
           className="rounded-md border border-gray-300 px-3 py-2"
         />
       </label>
+      {submitError ? (
+        <p className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-900" role="alert">
+          {submitError}
+        </p>
+      ) : null}
       <button
         type="submit"
-        className="rounded-full bg-teal-700 px-5 py-2.5 font-semibold text-white hover:bg-teal-800"
+        disabled={submitting}
+        className="rounded-full bg-teal-700 px-5 py-2.5 font-semibold text-white hover:bg-teal-800 disabled:opacity-60"
       >
-        {t('publicSite.lead.submit')}
+        {submitting ? t('publicSite.lead.submitting') : t('publicSite.lead.submit')}
       </button>
     </form>
   );

--- a/apps/web-site/src/lib/withContractRoute.ts
+++ b/apps/web-site/src/lib/withContractRoute.ts
@@ -1,0 +1,49 @@
+import type { NextRequest } from 'next/server';
+import { z } from 'zod';
+
+type ApiContract = {
+  path: string;
+  method: string;
+  request?: z.ZodType;
+  response: z.ZodType;
+};
+
+function errorResponse(status: number, error: string, details?: unknown): Response {
+  const body = details !== undefined ? { error, details } : { error };
+  return Response.json(body, { status });
+}
+
+export function withContractRoute<TRequest, TResponse>(
+  contract: ApiContract & {
+    request?: z.ZodType<TRequest>;
+    response: z.ZodType<TResponse>;
+  },
+  handler: (validatedRequest: TRequest | undefined) => Promise<TResponse>,
+): (request: NextRequest) => Promise<Response> {
+  return async (request: NextRequest) => {
+    try {
+      let validatedRequest: TRequest | undefined;
+
+      if (contract.method !== 'GET' && contract.request) {
+        const rawBody = await request.json();
+        const parsed = contract.request.safeParse(rawBody);
+        if (!parsed.success) {
+          return errorResponse(400, 'validation_error', parsed.error.flatten());
+        }
+        validatedRequest = parsed.data;
+      }
+
+      const result = await handler(validatedRequest);
+      const validated = contract.response.safeParse(result);
+      if (!validated.success) {
+        return errorResponse(500, 'internal_error');
+      }
+      return Response.json(validated.data);
+    } catch (err) {
+      if (err instanceof SyntaxError) {
+        return errorResponse(400, 'validation_error', 'Invalid JSON body');
+      }
+      return errorResponse(500, 'internal_error');
+    }
+  };
+}

--- a/apps/web-site/src/server/contact-lead.ts
+++ b/apps/web-site/src/server/contact-lead.ts
@@ -1,0 +1,34 @@
+/**
+ * Persist public contact form submissions (server-only, service role).
+ */
+import type { ContactLeadRequest, ContactLeadResponse } from '@myclup/contracts';
+import { createServerClient } from '@myclup/supabase';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+
+export async function persistContactLead(body: ContactLeadRequest): Promise<ContactLeadResponse> {
+  if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
+    return { ok: false, error: 'config_missing' };
+  }
+
+  const client = createServerClient({ supabaseUrl: SUPABASE_URL, serviceRoleKey: SERVICE_ROLE_KEY });
+
+  const { data, error } = await client
+    .from('marketing_leads')
+    .insert({
+      name: body.name,
+      email: body.email,
+      message: body.message ?? '',
+      locale: body.locale,
+      source: 'web_site_contact',
+    })
+    .select('id')
+    .single();
+
+  if (error || !data) {
+    return { ok: false, error: 'persist_failed' };
+  }
+
+  return { ok: true, id: data.id };
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -12,6 +12,7 @@ export * from './campaigns';
 export * from './chat';
 export * from './common';
 export * from './health';
+export * from './leads';
 export * from './listing';
 export * from './locale';
 export * from './members';

--- a/packages/contracts/src/leads/contact.test.ts
+++ b/packages/contracts/src/leads/contact.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { contactLeadRequestSchema } from './contact';
+
+describe('contactLeadRequestSchema', () => {
+  it('accepts minimal valid payload', () => {
+    const r = contactLeadRequestSchema.safeParse({
+      name: 'Ada',
+      email: 'ada@example.com',
+      message: 'Hello',
+      locale: 'en',
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects invalid email', () => {
+    const r = contactLeadRequestSchema.safeParse({
+      name: 'Ada',
+      email: 'not-an-email',
+      locale: 'en',
+    });
+    expect(r.success).toBe(false);
+  });
+});

--- a/packages/contracts/src/leads/contact.ts
+++ b/packages/contracts/src/leads/contact.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+export const contactLeadRequestSchema = z.object({
+  name: z.string().trim().min(1).max(200),
+  email: z.string().trim().email().max(320),
+  message: z.string().max(5000).optional().default(''),
+  locale: z.string().trim().min(2).max(32),
+});
+
+export const contactLeadResponseSchema = z.discriminatedUnion('ok', [
+  z.object({
+    ok: z.literal(true),
+    id: z.string().uuid(),
+  }),
+  z.object({
+    ok: z.literal(false),
+    error: z.enum(['validation_error', 'config_missing', 'persist_failed']),
+  }),
+]);
+
+export type ContactLeadRequest = z.infer<typeof contactLeadRequestSchema>;
+export type ContactLeadResponse = z.infer<typeof contactLeadResponseSchema>;
+
+export const contactLeadContract = {
+  path: '/api/v1/public/contact-leads',
+  method: 'POST' as const,
+  request: contactLeadRequestSchema,
+  response: contactLeadResponseSchema,
+} as const;

--- a/packages/contracts/src/leads/index.ts
+++ b/packages/contracts/src/leads/index.ts
@@ -1,0 +1,1 @@
+export * from './contact';

--- a/packages/i18n/src/namespaces/common/en.json
+++ b/packages/i18n/src/namespaces/common/en.json
@@ -594,7 +594,9 @@
       "email": "Email",
       "message": "How can we help?",
       "submit": "Send message",
-      "thanks": "Thanks — we will get back to you in your selected language where possible."
+      "submitting": "Sending…",
+      "thanks": "Thanks — we will get back to you in your selected language where possible.",
+      "errorSubmit": "We could not send your message. Please try again later."
     }
   },
   "discoveryWeb": {

--- a/packages/i18n/src/namespaces/common/tr.json
+++ b/packages/i18n/src/namespaces/common/tr.json
@@ -594,7 +594,9 @@
       "email": "E-posta",
       "message": "Nasıl yardımcı olabiliriz?",
       "submit": "Gönder",
-      "thanks": "Teşekkürler — mümkünse seçtiğiniz dilde size dönüş yapacağız."
+      "submitting": "Gönderiliyor…",
+      "thanks": "Teşekkürler — mümkünse seçtiğiniz dilde size dönüş yapacağız.",
+      "errorSubmit": "Mesajınız gönderilemedi. Lütfen daha sonra tekrar deneyin."
     }
   },
   "discoveryWeb": {

--- a/packages/supabase/src/generated/database.types.ts
+++ b/packages/supabase/src/generated/database.types.ts
@@ -918,6 +918,36 @@ export interface Database {
         };
         Relationships: [];
       };
+      marketing_leads: {
+        Row: {
+          id: string;
+          name: string;
+          email: string;
+          message: string;
+          locale: string;
+          source: string;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          name: string;
+          email: string;
+          message?: string;
+          locale?: string;
+          source?: string;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          name?: string;
+          email?: string;
+          message?: string;
+          locale?: string;
+          source?: string;
+          created_at?: string;
+        };
+        Relationships: [];
+      };
     };
     Views: Record<string, never>;
     Functions: Record<string, never>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -388,9 +388,15 @@ importers:
       '@myclup/analytics':
         specifier: workspace:*
         version: link:../../packages/analytics
+      '@myclup/contracts':
+        specifier: workspace:*
+        version: link:../../packages/contracts
       '@myclup/i18n':
         specifier: workspace:*
         version: link:../../packages/i18n
+      '@myclup/supabase':
+        specifier: workspace:*
+        version: link:../../packages/supabase
       '@myclup/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -406,6 +412,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
     devDependencies:
       '@myclup/config-eslint':
         specifier: workspace:*

--- a/supabase/migrations/20250323190000_create_marketing_leads.sql
+++ b/supabase/migrations/20250323190000_create_marketing_leads.sql
@@ -1,0 +1,16 @@
+-- Public marketing / website contact leads (server-side insert only via service role).
+CREATE TABLE public.marketing_leads (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  email text NOT NULL,
+  message text NOT NULL DEFAULT '',
+  locale text NOT NULL DEFAULT 'en',
+  source text NOT NULL DEFAULT 'web_site_contact',
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX marketing_leads_created_at_idx ON public.marketing_leads (created_at DESC);
+
+COMMENT ON TABLE public.marketing_leads IS 'Inbound leads from public website; no direct client reads; RLS denies anon/auth.';
+
+ALTER TABLE public.marketing_leads ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
Closes #241

## Summary
- `marketing_leads` Supabase table (service-role insert only; RLS enabled, no public policies)
- Shared `contactLeadContract` in `@myclup/contracts`
- Next.js BFF on `apps/web-site` for public POST
- Contact form posts with locale; i18n for loading/error

## Validation
`pnpm --filter @myclup/contracts build test`
`pnpm --filter @myclup/web-site test`
`pnpm --filter @myclup/i18n test`

Made with [Cursor](https://cursor.com)