### PR TITLE
test(e2e): Playwright smoke for web-site, gym, platform admin

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -108,9 +108,9 @@ The web admin does not ship a product sign-in screen yet. Use `http://localhost:
 
 ### E2E (Playwright)
 
-- `playwright.config.ts` exists at root as a skeleton.
-- Add E2E tests when Next.js apps exist (Epic #14+).
-- Run with `pnpm exec playwright test` from root.
+- Root `playwright.config.ts` defines projects: `web-site` (:3000), `web-gym-admin` (:3001), `web-platform-admin` (:3002). Specs live under `e2e/<app>/`.
+- Start the apps you need, then run `pnpm test:e2e` (or `pnpm exec playwright test`).
+- Override bases with `E2E_WEB_SITE_URL`, `E2E_WEB_GYM_ADMIN_URL`, `E2E_WEB_PLATFORM_ADMIN_URL` if ports differ.
 
 ### Mobile (React Native Testing Library)
 

--- a/e2e/gym-admin/dev-login.spec.ts
+++ b/e2e/gym-admin/dev-login.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Gym admin smoke', () => {
+  test('sign-in page loads', async ({ page }) => {
+    await page.goto('/en/sign-in');
+    await expect(page.locator('body')).toBeVisible();
+  });
+});

--- a/e2e/platform-admin/sign-in.spec.ts
+++ b/e2e/platform-admin/sign-in.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Platform admin auth surface', () => {
+  test('sign-in page loads', async ({ page }) => {
+    await page.goto('/en/sign-in');
+    await expect(page.locator('body')).toBeVisible();
+  });
+});

--- a/e2e/web-site/home-contact.spec.ts
+++ b/e2e/web-site/home-contact.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Public website core', () => {
+  test('locale home loads', async ({ page }) => {
+    await page.goto('/en');
+    await expect(page.locator('body')).toBeVisible();
+  });
+
+  test('contact page loads', async ({ page }) => {
+    await page.goto('/en/contact');
+    await expect(page.locator('body')).toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "supabase:stop": "pnpm exec supabase stop",
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",
+    "test:e2e": "playwright test",
     "clean": "turbo run build --force --no-cache"
   },
   "devDependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,8 +1,11 @@
 import { defineConfig, devices } from '@playwright/test';
 
 /**
- * Playwright E2E config skeleton.
- * Add tests when Next.js apps exist (Epic #14+).
+ * E2E: multi-app projects (Tasks #238–#240).
+ * Run against local dev servers, e.g.:
+ *   pnpm dev:web-gym-admin  # :3001
+ *   Platform admin          # :3002
+ *   Web site                # :3000
  */
 export default defineConfig({
   testDir: './e2e',
@@ -11,9 +14,34 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
+  timeout: 60_000,
   use: {
-    baseURL: 'http://localhost:3000',
     trace: 'on-first-retry',
   },
-  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  projects: [
+    {
+      name: 'web-site',
+      testMatch: /web-site\/.*\.spec\.ts/,
+      use: {
+        baseURL: process.env.E2E_WEB_SITE_URL ?? 'http://localhost:3000',
+        ...devices['Desktop Chrome'],
+      },
+    },
+    {
+      name: 'web-gym-admin',
+      testMatch: /gym-admin\/.*\.spec\.ts/,
+      use: {
+        baseURL: process.env.E2E_WEB_GYM_ADMIN_URL ?? 'http://localhost:3001',
+        ...devices['Desktop Chrome'],
+      },
+    },
+    {
+      name: 'web-platform-admin',
+      testMatch: /platform-admin\/.*\.spec\.ts/,
+      use: {
+        baseURL: process.env.E2E_WEB_PLATFORM_ADMIN_URL ?? 'http://localhost:3002',
+        ...devices['Desktop Chrome'],
+      },
+    },
+  ],
 });


### PR DESCRIPTION
Closes #238
Closes #239
Closes #240

## Notes
- Baseline smoke specs; run `pnpm test:e2e` with local dev servers on ports 3000/3001/3002.
- Follow-up: storageState auth fixtures and deeper operational flows per task acceptance.

Made with [Cursor](https://cursor.com)