### PR TITLE
feat(issues-236-237): mobile admin workouts and sales tabs

### DIFF
--- a/apps/mobile-admin/app/(tabs)/sales/index.tsx
+++ b/apps/mobile-admin/app/(tabs)/sales/index.tsx
@@ -74,6 +74,11 @@ export default function SalesLeadsScreen() {
             )}
           />
         </Card>
+
+        <Card>
+          <SectionHeader title={t('staffSales.webLeadsTitle')} subtitle="" />
+          <Text style={styles.webBody}>{t('staffSales.webLeadsBody')}</Text>
+        </Card>
       </View>
     </ScreenContainer>
   );
@@ -101,4 +106,10 @@ const styles = StyleSheet.create({
   },
   rowTitle: { fontSize: 16, fontWeight: '600', color: '#0f172a' },
   rowMeta: { fontSize: 13, color: '#64748b', marginTop: 4 },
+  webBody: {
+    marginTop: 8,
+    color: '#64748b',
+    fontSize: 15,
+    lineHeight: 22,
+  },
 });

--- a/apps/mobile-admin/app/(tabs)/workouts/index.tsx
+++ b/apps/mobile-admin/app/(tabs)/workouts/index.tsx
@@ -1,6 +1,14 @@
 import { useTranslation } from 'react-i18next';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, FlatList } from 'react-native';
 import { Card, ScreenContainer, SectionHeader } from '@myclup/ui-native';
+
+type TemplateRow = { id: string; titleKey: string; duration: string; focusKey: string };
+
+const TEMPLATE_ROWS: TemplateRow[] = [
+  { id: 'a', titleKey: 'staffWorkouts.templateA', duration: '45 min', focusKey: 'staffWorkouts.focusLower' },
+  { id: 'b', titleKey: 'staffWorkouts.templateB', duration: '20 min', focusKey: 'staffWorkouts.focusConditioning' },
+  { id: 'c', titleKey: 'staffWorkouts.templateC', duration: '15 min', focusKey: 'staffWorkouts.focusRecovery' },
+];
 
 export default function WorkoutsScreen() {
   const { t } = useTranslation('common');
@@ -11,6 +19,34 @@ export default function WorkoutsScreen() {
         <Card>
           <SectionHeader title={t('staffWorkouts.title')} subtitle={t('staffWorkouts.subtitle')} />
           <Text style={styles.body}>{t('staffWorkouts.placeholder')}</Text>
+        </Card>
+
+        <Card>
+          <SectionHeader
+            title={t('staffWorkouts.templatesTitle')}
+            subtitle={t('staffWorkouts.templatesSubtitle')}
+          />
+          <FlatList
+            data={TEMPLATE_ROWS}
+            keyExtractor={(item) => item.id}
+            scrollEnabled={false}
+            renderItem={({ item }) => (
+              <View style={styles.row}>
+                <Text style={styles.rowTitle}>{t(item.titleKey)}</Text>
+                <Text style={styles.rowMeta}>
+                  {t('staffWorkouts.templateMeta', {
+                    duration: item.duration,
+                    focus: t(item.focusKey),
+                  })}
+                </Text>
+              </View>
+            )}
+          />
+        </Card>
+
+        <Card>
+          <SectionHeader title={t('staffWorkouts.quickLogTitle')} subtitle="" />
+          <Text style={styles.body}>{t('staffWorkouts.quickLogBody')}</Text>
         </Card>
       </View>
     </ScreenContainer>
@@ -25,4 +61,11 @@ const styles = StyleSheet.create({
     fontSize: 15,
     lineHeight: 22,
   },
+  row: {
+    paddingVertical: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#e2e8f0',
+  },
+  rowTitle: { fontSize: 16, fontWeight: '600', color: '#0f172a' },
+  rowMeta: { fontSize: 13, color: '#64748b', marginTop: 4 },
 });

--- a/packages/i18n/src/namespaces/common/en.json
+++ b/packages/i18n/src/namespaces/common/en.json
@@ -110,7 +110,18 @@
   "staffWorkouts": {
     "title": "Workouts",
     "subtitle": "Programming and templates for instructors.",
-    "placeholder": "Workout builder and AI cleanup will connect to the shared AI service boundary. Use the web admin for full editing until mobile flows ship."
+    "placeholder": "Workout builder and AI cleanup will connect to the shared AI service boundary. Use the web admin for full editing until mobile flows ship.",
+    "templatesTitle": "Branch templates",
+    "templatesSubtitle": "Read-only previews until assignments sync from the gym admin panel.",
+    "templateA": "Strength block — lower body",
+    "templateB": "Metcon — 20 min cap",
+    "templateC": "Mobility reset",
+    "templateMeta": "{{duration}} · {{focus}}",
+    "quickLogTitle": "Session quick log",
+    "quickLogBody": "Per-member logs and AI-assisted text cleanup will use the server-side AI boundary (packages/ai) with explicit locale. For now, record details in the web admin workout tools.",
+    "focusLower": "Lower chain",
+    "focusConditioning": "Conditioning",
+    "focusRecovery": "Recovery"
   },
   "staffSales": {
     "title": "Leads",
@@ -123,7 +134,9 @@
     "pipelineTitle": "Today’s pipeline",
     "pipelineSubtitle": "Persisted on device via AsyncStorage until a staff lead sync API is available.",
     "empty": "No leads captured yet.",
-    "sourceUnknown": "Unknown source"
+    "sourceUnknown": "Unknown source",
+    "webLeadsTitle": "Website inquiries",
+    "webLeadsBody": "Contact submissions from the public marketing site are stored server-side. A staff-facing sync API will list them here once the gym BFF exposes tenant-scoped marketing leads."
   },
   "gymAdminWeb": {
     "productName": "Gym admin",

--- a/packages/i18n/src/namespaces/common/tr.json
+++ b/packages/i18n/src/namespaces/common/tr.json
@@ -110,7 +110,18 @@
   "staffWorkouts": {
     "title": "Antrenmanlar",
     "subtitle": "Eğitmenler için program ve şablonlar.",
-    "placeholder": "Antrenman oluşturucu ve AI düzenleme paylaşılan AI hizmet sınırına bağlanacak. Tam düzenleme için web yönetimini kullanın."
+    "placeholder": "Antrenman oluşturucu ve AI düzenleme paylaşılan AI hizmet sınırına bağlanacak. Tam düzenleme için web yönetimini kullanın.",
+    "templatesTitle": "Şube şablonları",
+    "templatesSubtitle": "Atamalar salon yönetim panelinden gelene kadar salt okunur önizleme.",
+    "templateA": "Kuvvet — alt gövde",
+    "templateB": "Metcon — 20 dk tavan",
+    "templateC": "Mobilite sıfırlama",
+    "templateMeta": "{{duration}} · {{focus}}",
+    "quickLogTitle": "Hızlı seans notu",
+    "quickLogBody": "Üye başına kayıtlar ve yapay zekâ destekli metin düzenleme, sunucu tarafı yapay zekâ sınırını (packages/ai) ve açık dili kullanacak. Şimdilik ayrıntıları web panelindeki antrenman araçlarına yazın.",
+    "focusLower": "Alt zincir",
+    "focusConditioning": "Kondisyon",
+    "focusRecovery": "Toparlanma"
   },
   "staffSales": {
     "title": "Potansiyel müşteriler",
@@ -123,7 +134,9 @@
     "pipelineTitle": "Bugünün hunisi",
     "pipelineSubtitle": "Personel lead senkron API’si gelene kadar AsyncStorage ile cihazda saklanır.",
     "empty": "Henüz kayıt yok.",
-    "sourceUnknown": "Kaynak bilinmiyor"
+    "sourceUnknown": "Kaynak bilinmiyor",
+    "webLeadsTitle": "Web sitesi talepleri",
+    "webLeadsBody": "Halka açık pazarlama sitesindeki iletişim formları sunucuda saklanır. Salon BFF kiracı kapsamlı pazarlama lead’lerini sunduğunda burada listelenecek."
   },
   "gymAdminWeb": {
     "productName": "Salon yönetimi",


### PR DESCRIPTION
Closes #236
Closes #237

## Summary
- **Workouts:** structured template preview cards + quick-log copy (AI boundary note).
- **Sales:** on-device pipeline unchanged; added **Website inquiries** section describing server-side marketing leads and future gym BFF sync (ties to #241).

## Tests
`pnpm --filter @myclup/i18n test`  
`pnpm --filter @myclup/mobile-admin test`

Made with [Cursor](https://cursor.com)